### PR TITLE
ft: add watering system

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npm run *)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .editor
+.claude/settings.local.json

--- a/src/game/gameState.ts
+++ b/src/game/gameState.ts
@@ -44,4 +44,6 @@ export const playerState = {
   // Visit mode — null means viewing own farm, address means visiting someone else
   viewingFarm: null as string | null,
   viewingFarmDisplayName: '',
+  // Tracks how many plots this visitor has watered in the current visit session (max 5)
+  visitorSessionWaterCount: 0,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { isServer } from '@dcl/sdk/network'
 import { getUserData } from '~system/UserIdentity'
 import { PlayerIdentityData } from '@dcl/sdk/ecs'
 import { setupUi } from './ui'
-import { setupEntities, unlockSoilsPhase1, unlockSoilsPhase2, unlockSoilsAll6, getSoilEntities, getComputerEntity, getTruckEntity } from './systems/interactionSetup'
+import { setupEntities, unlockSoilsPhase1, unlockSoilsPhase2, unlockSoilsAll6, getSoilEntities, getComputerEntity, getTruckEntity, initVisitorWaterFeedback } from './systems/interactionSetup'
 import './systems/growthSystem'
 import './systems/dogSystem'
 import './systems/seedVfxSystem'
@@ -44,6 +44,7 @@ export function main() {
   setupInputModifierSystem()
   initVisitService()
   initSocialService()
+  initVisitorWaterFeedback()
 
   // Wire soil-unlock callbacks BEFORE initTutorialSystem runs.
   // This resolves the circular dep: tutorialSystem → interactionSetup → actions → tutorialSystem.

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -188,6 +188,43 @@ export function setupFarmServer(): void {
     }
   })
 
+  room.onMessage('visitorWaterPlot', async (_data, context) => {
+    if (!context) return
+    const requester = context.from.toLowerCase()
+    const target    = ((_data.targetWallet as string) ?? '').toLowerCase()
+    const plotIndex = typeof _data.plotIndex === 'number' ? _data.plotIndex : -1
+    if (!target || plotIndex < 0) return
+    try {
+      const result = await store.waterFarmByVisitor(target, requester, getDisplayName(requester), plotIndex)
+      void room.send('visitorWaterResult', {
+        requester,
+        targetWallet: target,
+        plotIndex,
+        success:      result.success,
+        reason:       result.reason,
+      }, { to: [requester] })
+      if (result.success && result.reward) {
+        const targetFarm = store.get(target)
+        if (targetFarm) {
+          void room.send('socialOwnerWaterReceived', {
+            ownerWallet:      target,
+            reward:           result.reward,
+            notificationText: `${result.reward.fromName} watered your crops!`,
+          }, { to: [target] })
+        }
+      }
+    } catch (err) {
+      console.error('[FarmServer] visitorWaterPlot error:', err)
+      void room.send('visitorWaterResult', {
+        requester,
+        targetWallet: target,
+        plotIndex,
+        success:      false,
+        reason:       'server_error',
+      }, { to: [requester] })
+    }
+  })
+
   room.onMessage('collectMailbox', async (_data, context) => {
     if (!context) return
     const requester = context.from.toLowerCase()

--- a/src/server/storage/playerFarm.ts
+++ b/src/server/storage/playerFarm.ts
@@ -9,10 +9,19 @@ const FARM_KEY = 'farm_v1'
 const SCHEMA_VERSION = 2
 const LIKE_COOLDOWN_MS = 24 * 60 * 60 * 1000
 const LIKE_LEDGER_TTL_MS = 14 * LIKE_COOLDOWN_MS
+const WATER_LEDGER_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const VISITOR_WATER_DAILY_LIMIT = 5
 
 type LikeLedgerEntry = {
   visitorAddress: string
   lastLikedAt:    number
+}
+
+type VisitorWaterLedgerEntry = {
+  visitorAddress: string
+  plotIndex:      number
+  cropPlantedAt:  number
+  wateredAt:      number
 }
 
 // ---------------------------------------------------------------------------
@@ -52,6 +61,7 @@ export type FarmSaveV1 = {
   totalLikesReceived: number
   mailbox:        MailboxReward[]
   likeLedger:     LikeLedgerEntry[]
+  waterLedger:    VisitorWaterLedgerEntry[]
   updatedAt:      number
 }
 
@@ -93,6 +103,7 @@ function emptyFarm(wallet: string): FarmSaveV1 {
     totalLikesReceived: 0,
     mailbox:        [],
     likeLedger:     [],
+    waterLedger:    [],
     updatedAt:      Date.now(),
   }
 }
@@ -150,6 +161,14 @@ function normalizeFarm(raw: unknown, wallet: string): FarmSaveV1 {
       .map((entry) => ({
         visitorAddress: entry.visitorAddress.toLowerCase(),
         lastLikedAt:    safeInt(entry.lastLikedAt, 0),
+      })),
+    waterLedger:         safeArray<VisitorWaterLedgerEntry>(maybe.waterLedger)
+      .filter((entry) => typeof entry?.visitorAddress === 'string')
+      .map((entry) => ({
+        visitorAddress: entry.visitorAddress.toLowerCase(),
+        plotIndex:      safeInt(entry.plotIndex, 0),
+        cropPlantedAt:  safeInt(entry.cropPlantedAt, 0),
+        wateredAt:      safeInt(entry.wateredAt, 0),
       })),
     updatedAt:           safeInt(maybe.updatedAt, Date.now()),
   }
@@ -257,6 +276,7 @@ export class FarmProgressStore {
       totalLikesReceived:  existing.totalLikesReceived,
       mailbox:             existing.mailbox,
       likeLedger:          existing.likeLedger,
+      waterLedger:         existing.waterLedger,
       updatedAt:           Date.now(),
     }
 
@@ -329,6 +349,69 @@ export class FarmProgressStore {
       likeCount: farm.totalLikesReceived,
       rewardCoins,
     }
+  }
+
+  async waterFarmByVisitor(
+    targetAddress: string,
+    visitorAddress: string,
+    visitorName: string,
+    plotIndex: number,
+  ): Promise<{ success: boolean; reason: string; reward: MailboxReward | null }> {
+    const target  = targetAddress.toLowerCase()
+    const visitor = visitorAddress.toLowerCase()
+
+    if (!target || !visitor || target === visitor) {
+      return { success: false, reason: 'invalid_request', reward: null }
+    }
+
+    const farm = await this.load(target)
+    const now  = Date.now()
+
+    farm.waterLedger = farm.waterLedger.filter((e) => now - e.wateredAt <= WATER_LEDGER_TTL_MS)
+
+    const plotState = farm.plotStates.find((p) => p.plotIndex === plotIndex)
+    if (!plotState || plotState.cropType === -1) {
+      return { success: false, reason: 'no_crop', reward: null }
+    }
+    if (plotState.isReady) {
+      return { success: false, reason: 'crop_ready', reward: null }
+    }
+
+    const cropPlantedAt = plotState.plantedAt
+
+    const alreadyWatered = farm.waterLedger.some(
+      (e) => e.visitorAddress === visitor && e.plotIndex === plotIndex && e.cropPlantedAt === cropPlantedAt,
+    )
+    if (alreadyWatered) {
+      return { success: false, reason: 'already_watered_this_cycle', reward: null }
+    }
+
+    const DAY_MS = 24 * 60 * 60 * 1000
+    const dailyCount = farm.waterLedger.filter(
+      (e) => e.visitorAddress === visitor && now - e.wateredAt < DAY_MS,
+    ).length
+    if (dailyCount >= VISITOR_WATER_DAILY_LIMIT) {
+      return { success: false, reason: 'daily_limit_reached', reward: null }
+    }
+
+    const rewardAmount = 1 + Math.floor(Math.random() * 2)
+    const reward: MailboxReward = {
+      id:          `water:${now}:${visitor.slice(2, 10)}:${plotIndex}`,
+      type:        'seeds',
+      reason:      'visit_water',
+      amount:      rewardAmount,
+      cropType:    plotState.cropType,
+      fromAddress: visitor,
+      fromName:    visitorName || visitor.slice(0, 8),
+      createdAt:   now,
+    }
+
+    farm.waterLedger.push({ visitorAddress: visitor, plotIndex, cropPlantedAt, wateredAt: now })
+    farm.mailbox.unshift(reward)
+    farm.updatedAt = now
+    this.dirty.add(target)
+
+    return { success: true, reason: 'ok', reward }
   }
 
   async collectMailbox(address: string): Promise<{

--- a/src/services/socialService.ts
+++ b/src/services/socialService.ts
@@ -20,12 +20,25 @@ export const socialUiCallbacks = {
   }) => void) | null,
 }
 
+export const visitorWaterCallbacks = {
+  onWaterResult: null as ((data: {
+    targetWallet: string
+    plotIndex: number
+    success: boolean
+    reason: string
+  }) => void) | null,
+}
+
 export function requestLikeFarm(targetWallet: string): void {
   void room.send('socialLikeFarm', { targetWallet: targetWallet.toLowerCase() })
 }
 
 export function requestCollectMailbox(): void {
   void room.send('collectMailbox', {})
+}
+
+export function requestVisitorWaterPlot(targetWallet: string, plotIndex: number): void {
+  void room.send('visitorWaterPlot', { targetWallet: targetWallet.toLowerCase(), plotIndex })
 }
 
 function pushSocialToast(text: string): void {
@@ -83,6 +96,27 @@ export function initSocialService(): void {
       playerState.mailbox.unshift(data.reward)
     }
     playerState.totalLikesReceived = data.totalLikesReceived
+    pushSocialToast(data.notificationText)
+  })
+
+  room.onMessage('visitorWaterResult', (data) => {
+    if (data.requester !== playerState.wallet) return
+    if (data.success) {
+      playerState.visitorSessionWaterCount += 1
+    }
+    visitorWaterCallbacks.onWaterResult?.({
+      targetWallet: data.targetWallet,
+      plotIndex:    data.plotIndex,
+      success:      data.success,
+      reason:       data.reason,
+    })
+  })
+
+  room.onMessage('socialOwnerWaterReceived', (data) => {
+    if (data.ownerWallet !== playerState.wallet) return
+    if (!playerState.mailbox.find((r) => r.id === data.reward.id)) {
+      playerState.mailbox.unshift(data.reward)
+    }
     pushSocialToast(data.notificationText)
   })
 }

--- a/src/services/visitService.ts
+++ b/src/services/visitService.ts
@@ -8,6 +8,7 @@ import {
   pauseAutoSave, resumeAutoSave,
   visitCallbacks, registryCallbacks,
 } from './saveService'
+import { refreshAllPlotHoverTexts, clearVisitSessionWater } from '../systems/interactionSetup'
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -55,8 +56,11 @@ export function enterVisitMode(address: string, payload: FarmStatePayload): void
   restorePlotStates(payload.plotStates)
 
   playerState.viewingFarm = address
+  playerState.visitorSessionWaterCount = 0
   playerState.activeMenu  = 'none'
+  clearVisitSessionWater()
   pauseAutoSave()
+  refreshAllPlotHoverTexts()
 }
 
 export function exitVisitMode(): void {
@@ -71,10 +75,13 @@ export function exitVisitMode(): void {
 
   playerState.viewingFarm = null
   playerState.viewingFarmDisplayName = ''
+  playerState.visitorSessionWaterCount = 0
+  clearVisitSessionWater()
   resumeAutoSave()
   ownPlotSnapshot = null
   pendingVisitAddress = null
   visitedPayload = null
+  refreshAllPlotHoverTexts()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/farmMessages.ts
+++ b/src/shared/farmMessages.ts
@@ -214,6 +214,37 @@ const FarmMessages = {
     totalLikesReceived: Schemas.Int,
     notificationText:   Schemas.String,
   }),
+
+  /** Client → Server: visitor requests to water a plot on the farm they are visiting */
+  visitorWaterPlot: Schemas.Map({
+    targetWallet: Schemas.String,
+    plotIndex:    Schemas.Int,
+  }),
+
+  /** Server → Client (visitor): result of a visitor water attempt */
+  visitorWaterResult: Schemas.Map({
+    requester:    Schemas.String,
+    targetWallet: Schemas.String,
+    plotIndex:    Schemas.Int,
+    success:      Schemas.Boolean,
+    reason:       Schemas.String,
+  }),
+
+  /** Server → Client (owner): notification that a visitor watered a crop */
+  socialOwnerWaterReceived: Schemas.Map({
+    ownerWallet:      Schemas.String,
+    reward: Schemas.Map({
+      id:          Schemas.String,
+      type:        Schemas.String,
+      reason:      Schemas.String,
+      amount:      Schemas.Int,
+      cropType:    Schemas.Int,
+      fromAddress: Schemas.String,
+      fromName:    Schemas.String,
+      createdAt:   Schemas.Int64,
+    }),
+    notificationText: Schemas.String,
+  }),
 }
 
 export const room = registerMessages(FarmMessages)

--- a/src/systems/interactionSetup.ts
+++ b/src/systems/interactionSetup.ts
@@ -10,7 +10,7 @@ import { CROP_DATA, CROP_NAMES, CropType } from '../data/cropData'
 import { formatTime } from './growthSystem'
 import { tutorialState } from '../game/tutorialState'
 import { isVisiting } from '../services/visitService'
-import { requestVisitorWaterPlot } from '../services/socialService'
+import { requestVisitorWaterPlot, visitorWaterCallbacks } from '../services/socialService'
 import { playWateringVfx } from './wateringVfxSystem'
 
 const SOIL_MODEL             = 'assets/scene/Models/Soil01/Soil01.glb'
@@ -19,6 +19,18 @@ const SOIL_TRANSPARENT_MODEL = 'assets/scene/Models/Soil01Trasnparent/Soil01Tras
 // Tracks which plot indices were watered in the current visitor session
 const visitSessionWateredPlots = new Set<number>()
 export function clearVisitSessionWater(): void { visitSessionWateredPlots.clear() }
+
+export function initVisitorWaterFeedback(): void {
+  visitorWaterCallbacks.onWaterResult = (data) => {
+    const entity = soilEntities.find(
+      (e) => PlotState.get(e).plotIndex === data.plotIndex
+    )
+    if (!data.success) {
+      visitSessionWateredPlots.delete(data.plotIndex)
+    }
+    if (entity) updatePlotHoverText(entity)
+  }
+}
 
 // Icon position/size constants — tune here
 const COMPUTER_ICON_Y    = 3.2   // height above Computer entity origin
@@ -331,7 +343,7 @@ export function registerPlotPointerEvent(entity: Entity) {
     if (!plot.isUnlocked) {
       hoverText = 'Locked'
     } else if (plot.cropType !== -1 && !plot.isReady) {
-      hoverText = 'Water Crop'
+      hoverText = visitSessionWateredPlots.has(plot.plotIndex) ? 'Watered' : 'Water Crop'
     } else {
       hoverText = 'Visiting'
     }

--- a/src/systems/interactionSetup.ts
+++ b/src/systems/interactionSetup.ts
@@ -10,9 +10,15 @@ import { CROP_DATA, CROP_NAMES, CropType } from '../data/cropData'
 import { formatTime } from './growthSystem'
 import { tutorialState } from '../game/tutorialState'
 import { isVisiting } from '../services/visitService'
+import { requestVisitorWaterPlot } from '../services/socialService'
+import { playWateringVfx } from './wateringVfxSystem'
 
 const SOIL_MODEL             = 'assets/scene/Models/Soil01/Soil01.glb'
 const SOIL_TRANSPARENT_MODEL = 'assets/scene/Models/Soil01Trasnparent/Soil01Trasnparent.glb'
+
+// Tracks which plot indices were watered in the current visitor session
+const visitSessionWateredPlots = new Set<number>()
+export function clearVisitSessionWater(): void { visitSessionWateredPlots.clear() }
 
 // Icon position/size constants — tune here
 const COMPUTER_ICON_Y    = 3.2   // height above Computer entity origin
@@ -298,11 +304,38 @@ export function unlockSoilsAll6(): void {
   console.log('CozyFarm Tutorial: unlocked all 6 soil plots (skip)')
 }
 
+function handleVisitorPlotClick(entity: Entity): void {
+  const plot = PlotState.get(entity)
+  if (plot.cropType === -1 || plot.isReady || plot.isWatering || plot.isPlanting) return
+
+  const targetFarm = playerState.viewingFarm
+  if (!targetFarm) return
+
+  if (playerState.visitorSessionWaterCount >= 5) return
+  if (visitSessionWateredPlots.has(plot.plotIndex)) return
+
+  visitSessionWateredPlots.add(plot.plotIndex)
+  PlotState.getMutable(entity).isWatering = true
+  playWateringVfx(entity)
+  playSound('wateringcan')
+  requestVisitorWaterPlot(targetFarm, plot.plotIndex)
+}
+
 export function registerPlotPointerEvent(entity: Entity) {
   const plot = PlotState.get(entity)
+  const visiting = isVisiting()
 
   let hoverText = 'Plant'
-  if (!plot.isUnlocked) {
+
+  if (visiting) {
+    if (!plot.isUnlocked) {
+      hoverText = 'Locked'
+    } else if (plot.cropType !== -1 && !plot.isReady) {
+      hoverText = 'Water Crop'
+    } else {
+      hoverText = 'Visiting'
+    }
+  } else if (!plot.isUnlocked) {
     hoverText = 'Locked'
   } else if (plot.cropType !== -1) {
     if (plot.isReady) {
@@ -331,8 +364,17 @@ export function registerPlotPointerEvent(entity: Entity) {
 
   pointerEventsSystem.onPointerDown(
     { entity, opts: { button: InputAction.IA_POINTER, hoverText, maxDistance: 8 } },
-    () => { if (isVisiting()) return; handlePlotClick(entity) }
+    () => {
+      if (isVisiting()) { handleVisitorPlotClick(entity); return }
+      handlePlotClick(entity)
+    }
   )
+}
+
+export function refreshAllPlotHoverTexts(): void {
+  for (const entity of soilEntities) {
+    updatePlotHoverText(entity)
+  }
 }
 
 export function updatePlotHoverText(entity: Entity) {

--- a/src/ui/VisitHud.tsx
+++ b/src/ui/VisitHud.tsx
@@ -15,6 +15,7 @@ const likeUiState = {
 
 const VISIT_HUD_W = 700
 const VISIT_INFO_W = 360
+const VISITOR_WATER_LIMIT = 5
 
 function syncLikeUi(targetFarm: string): void {
   if (likeUiState.farm === targetFarm) return
@@ -47,13 +48,19 @@ export const VisitHud = () => {
       : 'Could not register like'
   }
 
-  const payload    = getVisitedPayload()
-  const likeCount  = payload?.wallet === targetFarm ? payload.totalLikesReceived : 0
-  const farmLabel  = formatPlayerLabel(playerState.viewingFarmDisplayName, targetFarm)
-  const likeLabel  = likeUiState.pending ? 'Liking...' : likeUiState.liked ? 'Liked Today' : 'Like Farm'
-  const likeBg     = likeUiState.liked
+  const payload      = getVisitedPayload()
+  const likeCount    = payload?.wallet === targetFarm ? payload.totalLikesReceived : 0
+  const farmLabel    = formatPlayerLabel(playerState.viewingFarmDisplayName, targetFarm)
+  const likeLabel    = likeUiState.pending ? 'Liking...' : likeUiState.liked ? 'Liked Today' : 'Like Farm'
+  const likeBg       = likeUiState.liked
     ? { r: 0.35, g: 0.18, b: 0.18, a: 1 }
     : { r: 0.58, g: 0.22, b: 0.22, a: 1 }
+  const waterCount   = playerState.visitorSessionWaterCount
+  const waterLeft    = VISITOR_WATER_LIMIT - waterCount
+  const waterLabel   = `Water ${waterCount}/${VISITOR_WATER_LIMIT}`
+  const waterBg      = waterLeft > 0
+    ? { r: 0.12, g: 0.35, b: 0.55, a: 1 }
+    : { r: 0.2, g: 0.2, b: 0.2, a: 1 }
 
   return (
     <UiEntity
@@ -112,6 +119,13 @@ export const VisitHud = () => {
           } : undefined}
         >
           <Label value={likeLabel} fontSize={18} color={C.textMain} textAlign="middle-center" />
+        </UiEntity>
+
+        <UiEntity
+          uiTransform={{ width: 130, height: 44, alignItems: 'center', justifyContent: 'center', margin: { right: 10 } }}
+          uiBackground={{ color: waterBg }}
+        >
+          <Label value={waterLabel} fontSize={17} color={C.textMain} textAlign="middle-center" />
         </UiEntity>
 
         <UiEntity


### PR DESCRIPTION
## Visitor Watering System

Adds a social interaction mechanic where players can water crops on farms they visit, rewarding the farm owner with seeds in their mailbox.

### Changes

**Server-side** (`src/shared/farmMessages.ts`, `src/server/storage/playerFarm.ts`, `src/server/farmServer.ts`)

- New messages: `visitorWaterPlot`, `visitorWaterResult`, `socialOwnerWaterReceived`
- `waterFarmByVisitor` method on `FarmProgressStore`: validates the request, checks per-plot-per-cycle and daily limits, generates a seed reward, and persists both the ledger entry and the mailbox reward
- `waterLedger` on `FarmSaveV1`: server-only ledger tracking visitor/plot/cropCycle tuples with a 7-day TTL — mirrors the existing `likeLedger` pattern

**Client-side** (`src/services/socialService.ts`, `src/systems/interactionSetup.ts`, `src/services/visitService.ts`, `src/game/gameState.ts`, `src/ui/VisitHud.tsx`)

- `requestVisitorWaterPlot` sends the water request; `visitorWaterCallbacks.onWaterResult` surfaces the result
- `handleVisitorPlotClick` in `interactionSetup.ts` runs the watering flow when in visit mode: guards against no crop, ready crops, session limit, and already-watered plots, then triggers VFX + sound
- `visitSessionWateredPlots` Set (cleared on enter/exit visit mode) prevents re-clicking a plot after the VFX animation clears `isWatering`
- `visitorSessionWaterCount` in `playerState` tracks waterings for the current visit session (max 5)
- Visit HUD shows a `Water N/5` badge; turns grey when the session limit is reached
- Farm owner receives `socialOwnerWaterReceived` push notification and mailbox seed reward — separate from `socialOwnerRewardReceived` to avoid clobbering `totalLikesReceived`

### Limits enforced

| Rule | Where |
|------|------|
| Max 5 waterings per visit session | Client (immediate) + Server (daily ledger) |
| 1 watering per plot per crop cycle | Server (`waterLedger` keyed by visitor + plotIndex + `cropPlantedAt`) |
| Cannot water own farm | Server (`target === visitor` guard) |
| Cannot water ready/empty crops | Client + Server |

Closes #17 