### PR TITLE
ft: add worker wage system

### DIFF
--- a/src/game/gameState.ts
+++ b/src/game/gameState.ts
@@ -16,6 +16,9 @@ export const playerState = {
   farmerHired: false,
   farmerSeeds: new Map<CropType, number>(),
   farmerInventory: new Map<CropType, number>(),
+  workerOutstandingWages: 0,
+  workerUnpaidDays: 0,
+  workerLastWageProcessedAt: 0,
   // Leveling
   xp: 0,
   level: 1,

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -4,6 +4,7 @@ import {
   createFarmProgressStore, farmSaveToPayload,
   updatePlayerRegistry, loadPlayerRegistryPage, loadBeautyLeaderboard,
 } from './storage/playerFarm'
+import { WORKER_DEBUG_ENABLED } from '../shared/worker'
 
 // ---------------------------------------------------------------------------
 // Auto-save interval (seconds) — same cadence as reference project
@@ -51,6 +52,20 @@ async function loadAndSend(address: string): Promise<void> {
   void updatePlayerRegistry(normalized, farm.level, getDisplayName(normalized))
 }
 
+function sendWorkerStatus(address: string): void {
+  const normalized = address.toLowerCase()
+  const farm = store.get(normalized)
+  if (!farm) return
+
+  void room.send('workerStatusUpdated', {
+    requester: normalized,
+    coinsDelta: 0,
+    workerOutstandingWages: farm.workerOutstandingWages,
+    workerUnpaidDays: farm.workerUnpaidDays,
+    workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+  }, { to: [normalized] })
+}
+
 // ---------------------------------------------------------------------------
 // Auto-save system — runs every frame, flushes dirty entries every N seconds
 // ---------------------------------------------------------------------------
@@ -58,6 +73,29 @@ function farmAutosaveSystem(dt: number): void {
   autosaveAccumulator += dt
   if (autosaveAccumulator < AUTOSAVE_INTERVAL_SECONDS) return
   autosaveAccumulator = 0
+  for (const address of loadedAddresses) {
+    const before = store.get(address)
+    const prevCoins = before?.coins ?? 0
+    const prevOutstanding = before?.workerOutstandingWages ?? 0
+    const prevUnpaidDays = before?.workerUnpaidDays ?? 0
+    const prevLastProcessedAt = before?.workerLastWageProcessedAt ?? 0
+    void store.load(address).then((farm) => {
+      const changed =
+        prevCoins !== farm.coins ||
+        prevOutstanding !== farm.workerOutstandingWages ||
+        prevUnpaidDays !== farm.workerUnpaidDays ||
+        prevLastProcessedAt !== farm.workerLastWageProcessedAt
+      if (!changed) return
+
+      void room.send('workerStatusUpdated', {
+        requester: address,
+        coinsDelta: farm.coins - prevCoins,
+        workerOutstandingWages: farm.workerOutstandingWages,
+        workerUnpaidDays: farm.workerUnpaidDays,
+        workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+      }, { to: [address] })
+    })
+  }
   void store.saveDirty()
 }
 
@@ -90,6 +128,90 @@ export function setupFarmServer(): void {
     if (saved) void updatePlayerRegistry(normalized, saved.level, getDisplayName(normalized), saved.beautyScore)
     // Bust leaderboard cache on every save so rankings stay fresh
     leaderboardCache = null
+  })
+
+  room.onMessage('payWorkerWages', async (_data, context) => {
+    if (!context) return
+    const requester = context.from.toLowerCase()
+    try {
+      const result = await store.payWorkerWages(requester)
+      void room.send('workerWagePaymentResult', {
+        requester,
+        success: result.success,
+        reason: result.reason,
+        coinsDelta: result.coinsDelta,
+        workerOutstandingWages: result.workerOutstandingWages,
+        workerUnpaidDays: result.workerUnpaidDays,
+        workerLastWageProcessedAt: result.workerLastWageProcessedAt,
+      }, { to: [requester] })
+    } catch (err) {
+      console.error('[FarmServer] payWorkerWages error:', err)
+      sendWorkerStatus(requester)
+      void room.send('workerWagePaymentResult', {
+        requester,
+        success: false,
+        reason: 'server_error',
+        coinsDelta: 0,
+        workerOutstandingWages: store.get(requester)?.workerOutstandingWages ?? 0,
+        workerUnpaidDays: store.get(requester)?.workerUnpaidDays ?? 0,
+        workerLastWageProcessedAt: store.get(requester)?.workerLastWageProcessedAt ?? 0,
+      }, { to: [requester] })
+    }
+  })
+
+  room.onMessage('debugWorkerAction', async (_data, context) => {
+    if (!context) return
+    const requester = context.from.toLowerCase()
+    if (!WORKER_DEBUG_ENABLED) {
+      const farm = store.get(requester)
+      void room.send('debugWorkerStateUpdated', {
+        requester,
+        success: false,
+        reason: 'debug_disabled',
+        coins: farm?.coins ?? 0,
+        cropsUnlocked: farm?.cropsUnlocked ?? false,
+        farmerHired: farm?.farmerHired ?? false,
+        farmerSeeds: farm?.farmerSeeds ?? [],
+        workerOutstandingWages: farm?.workerOutstandingWages ?? 0,
+        workerUnpaidDays: farm?.workerUnpaidDays ?? 0,
+        workerLastWageProcessedAt: farm?.workerLastWageProcessedAt ?? 0,
+      }, { to: [requester] })
+      return
+    }
+    try {
+      const result = await store.debugWorkerAction(
+        requester,
+        typeof _data.action === 'string' ? _data.action : '',
+        typeof _data.amount === 'number' ? _data.amount : 0,
+      )
+      void room.send('debugWorkerStateUpdated', {
+        requester,
+        success: result.success,
+        reason: result.reason,
+        coins: result.coins,
+        cropsUnlocked: result.cropsUnlocked,
+        farmerHired: result.farmerHired,
+        farmerSeeds: result.farmerSeeds,
+        workerOutstandingWages: result.workerOutstandingWages,
+        workerUnpaidDays: result.workerUnpaidDays,
+        workerLastWageProcessedAt: result.workerLastWageProcessedAt,
+      }, { to: [requester] })
+    } catch (err) {
+      console.error('[FarmServer] debugWorkerAction error:', err)
+      const farm = store.get(requester)
+      void room.send('debugWorkerStateUpdated', {
+        requester,
+        success: false,
+        reason: 'server_error',
+        coins: farm?.coins ?? 0,
+        cropsUnlocked: farm?.cropsUnlocked ?? false,
+        farmerHired: farm?.farmerHired ?? false,
+        farmerSeeds: farm?.farmerSeeds ?? [],
+        workerOutstandingWages: farm?.workerOutstandingWages ?? 0,
+        workerUnpaidDays: farm?.workerUnpaidDays ?? 0,
+        workerLastWageProcessedAt: farm?.workerLastWageProcessedAt ?? 0,
+      }, { to: [requester] })
+    }
   })
 
   // Serve the paginated player registry

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -73,13 +73,15 @@ function farmAutosaveSystem(dt: number): void {
   autosaveAccumulator += dt
   if (autosaveAccumulator < AUTOSAVE_INTERVAL_SECONDS) return
   autosaveAccumulator = 0
-  for (const address of loadedAddresses) {
-    const before = store.get(address)
-    const prevCoins = before?.coins ?? 0
-    const prevOutstanding = before?.workerOutstandingWages ?? 0
-    const prevUnpaidDays = before?.workerUnpaidDays ?? 0
-    const prevLastProcessedAt = before?.workerLastWageProcessedAt ?? 0
-    void store.load(address).then((farm) => {
+  void (async () => {
+    await Promise.all([...loadedAddresses].map(async (address) => {
+      const before = store.get(address)
+      const prevCoins = before?.coins ?? 0
+      const prevOutstanding = before?.workerOutstandingWages ?? 0
+      const prevUnpaidDays = before?.workerUnpaidDays ?? 0
+      const prevLastProcessedAt = before?.workerLastWageProcessedAt ?? 0
+      const farm = await store.load(address)
+
       const changed =
         prevCoins !== farm.coins ||
         prevOutstanding !== farm.workerOutstandingWages ||
@@ -94,9 +96,10 @@ function farmAutosaveSystem(dt: number): void {
         workerUnpaidDays: farm.workerUnpaidDays,
         workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
       }, { to: [address] })
-    })
-  }
-  void store.saveDirty()
+    }))
+
+    await store.saveDirty()
+  })()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/storage/playerFarm.ts
+++ b/src/server/storage/playerFarm.ts
@@ -1,12 +1,14 @@
 import { Storage } from '@dcl/sdk/server'
 import type { FarmStatePayload, PlotSaveState, CropCount, QuestProgressSave, PlayerEntry, MailboxReward } from '../../shared/farmMessages'
 import { calculateBeautyScore } from '../../game/beautyScore'
+import { WORKER_DAILY_WAGE, WORKER_DAY_MS } from '../../shared/worker'
+import { CropType } from '../../data/cropData'
 
 // ---------------------------------------------------------------------------
 // Storage keys + schema version
 // ---------------------------------------------------------------------------
 const FARM_KEY = 'farm_v1'
-const SCHEMA_VERSION = 2
+const SCHEMA_VERSION = 3
 const LIKE_COOLDOWN_MS = 24 * 60 * 60 * 1000
 const LIKE_LEDGER_TTL_MS = 14 * LIKE_COOLDOWN_MS
 const WATER_LEDGER_TTL_MS = 7 * 24 * 60 * 60 * 1000
@@ -41,6 +43,9 @@ export type FarmSaveV1 = {
   farmerHired:        boolean
   farmerSeeds:      CropCount[]
   farmerInventory:  CropCount[]
+  workerOutstandingWages: number
+  workerUnpaidDays:       number
+  workerLastWageProcessedAt: number
   dogOwned:         boolean
   totalCropsHarvested: number
   totalWaterCount:     number
@@ -83,6 +88,9 @@ function emptyFarm(wallet: string): FarmSaveV1 {
     farmerHired: false,
     farmerSeeds: [],
     farmerInventory: [],
+    workerOutstandingWages: 0,
+    workerUnpaidDays: 0,
+    workerLastWageProcessedAt: 0,
     dogOwned: false,
     totalCropsHarvested: 0,
     totalWaterCount: 0,
@@ -137,6 +145,9 @@ function normalizeFarm(raw: unknown, wallet: string): FarmSaveV1 {
     farmerHired:        safeBool(maybe.farmerHired),
     farmerSeeds:      safeArray<CropCount>(maybe.farmerSeeds),
     farmerInventory:  safeArray<CropCount>(maybe.farmerInventory),
+    workerOutstandingWages: safeInt(maybe.workerOutstandingWages, 0),
+    workerUnpaidDays:       safeInt(maybe.workerUnpaidDays, 0),
+    workerLastWageProcessedAt: safeInt(maybe.workerLastWageProcessedAt, 0),
     dogOwned:         safeBool(maybe.dogOwned),
     totalCropsHarvested: safeInt(maybe.totalCropsHarvested),
     totalWaterCount:     safeInt(maybe.totalWaterCount),
@@ -191,6 +202,9 @@ export function farmSaveToPayload(save: FarmSaveV1): FarmStatePayload {
     farmerHired:         save.farmerHired,
     farmerSeeds:         save.farmerSeeds,
     farmerInventory:     save.farmerInventory,
+    workerOutstandingWages: save.workerOutstandingWages,
+    workerUnpaidDays:       save.workerUnpaidDays,
+    workerLastWageProcessedAt: save.workerLastWageProcessedAt,
     dogOwned:            save.dogOwned,
     totalCropsHarvested: save.totalCropsHarvested,
     totalWaterCount:     save.totalWaterCount,
@@ -220,16 +234,51 @@ export class FarmProgressStore {
   private cache = new Map<string, FarmSaveV1>()
   private dirty = new Set<string>()
 
+  private settleWorkerWages(farm: FarmSaveV1, now = Date.now()): boolean {
+    if (!farm.farmerHired) {
+      let changed = false
+      if (farm.workerOutstandingWages !== 0) { farm.workerOutstandingWages = 0; changed = true }
+      if (farm.workerUnpaidDays !== 0) { farm.workerUnpaidDays = 0; changed = true }
+      if (farm.workerLastWageProcessedAt !== 0) { farm.workerLastWageProcessedAt = 0; changed = true }
+      if (changed) farm.updatedAt = now
+      return changed
+    }
+
+    if (farm.workerLastWageProcessedAt <= 0 || farm.workerLastWageProcessedAt > now) {
+      farm.workerLastWageProcessedAt = now
+      farm.updatedAt = now
+      return true
+    }
+
+    const elapsedDays = Math.floor((now - farm.workerLastWageProcessedAt) / WORKER_DAY_MS)
+    if (elapsedDays <= 0) return false
+
+    for (let day = 0; day < elapsedDays; day++) {
+      if (farm.coins >= WORKER_DAILY_WAGE) {
+        farm.coins -= WORKER_DAILY_WAGE
+      } else {
+        farm.workerOutstandingWages += WORKER_DAILY_WAGE
+        farm.workerUnpaidDays += 1
+      }
+    }
+
+    farm.workerLastWageProcessedAt += elapsedDays * WORKER_DAY_MS
+    farm.updatedAt = now
+    return true
+  }
+
   async load(address: string): Promise<FarmSaveV1> {
     const key = address.toLowerCase()
-    const cached = this.cache.get(key)
-    if (cached) return cached
+    let farm = this.cache.get(key)
+    if (!farm) {
+      const raw = await Storage.player.get<unknown>(key, FARM_KEY)
+      farm = normalizeFarm(raw, key)
+      this.cache.set(key, farm)
+      // Always write canonical format on first load
+      this.dirty.add(key)
+    }
 
-    const raw = await Storage.player.get<unknown>(key, FARM_KEY)
-    const farm = normalizeFarm(raw, key)
-    this.cache.set(key, farm)
-    // Always write canonical format on first load
-    this.dirty.add(key)
+    if (this.settleWorkerWages(farm)) this.dirty.add(key)
     return farm
   }
 
@@ -240,6 +289,13 @@ export class FarmProgressStore {
   applyPayload(address: string, payload: FarmStatePayload): void {
     const key = address.toLowerCase()
     const existing = this.cache.get(key) ?? emptyFarm(key)
+    const farmerHired = existing.farmerHired || payload.farmerHired
+    const hiredNow = !existing.farmerHired && farmerHired
+    const workerLastWageProcessedAt = hiredNow
+      ? Math.max(0, payload.workerLastWageProcessedAt || Date.now())
+      : existing.workerLastWageProcessedAt
+    const workerOutstandingWages = hiredNow ? 0 : existing.workerOutstandingWages
+    const workerUnpaidDays = hiredNow ? 0 : existing.workerUnpaidDays
 
     const updated: FarmSaveV1 = {
       schemaVersion:       SCHEMA_VERSION,
@@ -249,12 +305,15 @@ export class FarmProgressStore {
       harvested:           payload.harvested,
       xp:                  payload.xp,
       level:               payload.level,
-      cropsUnlocked:       payload.cropsUnlocked,
-      expansion1Unlocked:  payload.expansion1Unlocked,
-      expansion2Unlocked:  payload.expansion2Unlocked,
-      farmerHired:         payload.farmerHired,
+      cropsUnlocked:       existing.cropsUnlocked || payload.cropsUnlocked,
+      expansion1Unlocked:  existing.expansion1Unlocked || payload.expansion1Unlocked,
+      expansion2Unlocked:  existing.expansion2Unlocked || payload.expansion2Unlocked,
+      farmerHired,
       farmerSeeds:         payload.farmerSeeds,
       farmerInventory:     payload.farmerInventory,
+      workerOutstandingWages,
+      workerUnpaidDays,
+      workerLastWageProcessedAt: farmerHired ? workerLastWageProcessedAt : 0,
       dogOwned:            payload.dogOwned,
       totalCropsHarvested: payload.totalCropsHarvested,
       totalWaterCount:     payload.totalWaterCount,
@@ -288,6 +347,168 @@ export class FarmProgressStore {
 
     // Keep existing reference up-to-date for any in-flight code that holds it
     Object.assign(existing, updated)
+  }
+
+  async payWorkerWages(address: string): Promise<{
+    success: boolean
+    reason: string
+    coinsDelta: number
+    workerOutstandingWages: number
+    workerUnpaidDays: number
+    workerLastWageProcessedAt: number
+  }> {
+    const key = address.toLowerCase()
+    const farm = await this.load(key)
+
+    if (!farm.farmerHired) {
+      return {
+        success: false,
+        reason: 'worker_not_hired',
+        coinsDelta: 0,
+        workerOutstandingWages: farm.workerOutstandingWages,
+        workerUnpaidDays: farm.workerUnpaidDays,
+        workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+      }
+    }
+
+    if (farm.workerOutstandingWages <= 0) {
+      return {
+        success: false,
+        reason: 'no_debt',
+        coinsDelta: 0,
+        workerOutstandingWages: 0,
+        workerUnpaidDays: farm.workerUnpaidDays,
+        workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+      }
+    }
+
+    if (farm.coins < farm.workerOutstandingWages) {
+      return {
+        success: false,
+        reason: 'insufficient_coins',
+        coinsDelta: 0,
+        workerOutstandingWages: farm.workerOutstandingWages,
+        workerUnpaidDays: farm.workerUnpaidDays,
+        workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+      }
+    }
+
+    const coinsDelta = -farm.workerOutstandingWages
+    farm.coins += coinsDelta
+    farm.workerOutstandingWages = 0
+    farm.workerUnpaidDays = 0
+    farm.updatedAt = Date.now()
+    this.dirty.add(key)
+
+    return {
+      success: true,
+      reason: 'ok',
+      coinsDelta,
+      workerOutstandingWages: farm.workerOutstandingWages,
+      workerUnpaidDays: farm.workerUnpaidDays,
+      workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+    }
+  }
+
+  async debugWorkerAction(address: string, action: string, amount: number): Promise<{
+    success: boolean
+    reason: string
+    coins: number
+    cropsUnlocked: boolean
+    farmerHired: boolean
+    farmerSeeds: CropCount[]
+    workerOutstandingWages: number
+    workerUnpaidDays: number
+    workerLastWageProcessedAt: number
+  }> {
+    const key = address.toLowerCase()
+    const farm = await this.load(key)
+    const now = Date.now()
+    const safeAmount = Number.isFinite(amount) ? Math.max(0, Math.floor(amount)) : 0
+
+    switch (action) {
+      case 'setup': {
+        farm.cropsUnlocked = true
+        farm.farmerHired = true
+        farm.coins = Math.max(farm.coins, 5000)
+        farm.workerOutstandingWages = 0
+        farm.workerUnpaidDays = 0
+        farm.workerLastWageProcessedAt = now
+        farm.farmerSeeds = [{ cropType: CropType.Onion, count: 20 }]
+        break
+      }
+
+      case 'add_coins': {
+        farm.coins += safeAmount
+        break
+      }
+
+      case 'set_coins': {
+        farm.coins = safeAmount
+        break
+      }
+
+      case 'load_seeds': {
+        const existing = farm.farmerSeeds.find((seed) => seed.cropType === CropType.Onion)
+        if (existing) existing.count += Math.max(1, safeAmount || 20)
+        else farm.farmerSeeds.push({ cropType: CropType.Onion, count: Math.max(1, safeAmount || 20) })
+        break
+      }
+
+      case 'clear_seeds': {
+        farm.farmerSeeds = []
+        break
+      }
+
+      case 'advance_days': {
+        if (!farm.farmerHired) {
+          farm.farmerHired = true
+          farm.workerLastWageProcessedAt = now
+        }
+        if (farm.workerLastWageProcessedAt <= 0) farm.workerLastWageProcessedAt = now
+        farm.workerLastWageProcessedAt -= Math.max(1, safeAmount || 1) * WORKER_DAY_MS
+        this.settleWorkerWages(farm, now)
+        break
+      }
+
+      case 'clear_debt': {
+        farm.workerOutstandingWages = 0
+        farm.workerUnpaidDays = 0
+        if (farm.farmerHired && farm.workerLastWageProcessedAt <= 0) {
+          farm.workerLastWageProcessedAt = now
+        }
+        break
+      }
+
+      default:
+        return {
+          success: false,
+          reason: 'unknown_action',
+          coins: farm.coins,
+          cropsUnlocked: farm.cropsUnlocked,
+          farmerHired: farm.farmerHired,
+          farmerSeeds: farm.farmerSeeds,
+          workerOutstandingWages: farm.workerOutstandingWages,
+          workerUnpaidDays: farm.workerUnpaidDays,
+          workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+        }
+    }
+
+    farm.coins = Math.max(0, farm.coins)
+    farm.updatedAt = now
+    this.dirty.add(key)
+
+    return {
+      success: true,
+      reason: action,
+      coins: farm.coins,
+      cropsUnlocked: farm.cropsUnlocked,
+      farmerHired: farm.farmerHired,
+      farmerSeeds: farm.farmerSeeds,
+      workerOutstandingWages: farm.workerOutstandingWages,
+      workerUnpaidDays: farm.workerUnpaidDays,
+      workerLastWageProcessedAt: farm.workerLastWageProcessedAt,
+    }
   }
 
   async likeFarm(targetAddress: string, visitorAddress: string, visitorName: string): Promise<{

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -15,6 +15,8 @@ import {
 import { questProgressMap, QuestStatus } from '../game/questState'
 import { musicState } from '../game/musicState'
 import { playSong, setMuted, setMusicVolume } from '../systems/musicSystem'
+import { removeForSaleSign, unlockFarmerPlots } from '../systems/interactionSetup'
+import { spawnFarmer } from '../systems/farmerSystem'
 
 // ---------------------------------------------------------------------------
 // Auto-save interval
@@ -81,6 +83,9 @@ export function buildSavePayload(): FarmStatePayload {
     farmerHired:        playerState.farmerHired,
     farmerSeeds:     mapToArray(playerState.farmerSeeds),
     farmerInventory: mapToArray(playerState.farmerInventory),
+    workerOutstandingWages: playerState.workerOutstandingWages,
+    workerUnpaidDays: playerState.workerUnpaidDays,
+    workerLastWageProcessedAt: playerState.workerLastWageProcessedAt,
     dogOwned:        playerState.dogOwned,
     totalCropsHarvested: playerState.totalCropsHarvested,
     totalWaterCount:     playerState.totalWaterCount,
@@ -139,6 +144,15 @@ function applyPayload(payload: FarmStatePayload): void {
   playerState.farmerHired      = payload.farmerHired
   playerState.farmerSeeds      = arrayToMap(payload.farmerSeeds)
   playerState.farmerInventory  = arrayToMap(payload.farmerInventory)
+  playerState.workerOutstandingWages = payload.workerOutstandingWages ?? 0
+  playerState.workerUnpaidDays = payload.workerUnpaidDays ?? 0
+  playerState.workerLastWageProcessedAt = payload.workerLastWageProcessedAt ?? 0
+
+  if (payload.cropsUnlocked) {
+    removeForSaleSign()
+    unlockFarmerPlots()
+    spawnFarmer()
+  }
 
   // ── Dog ───────────────────────────────────────────────────────────────────
   playerState.dogOwned = payload.dogOwned
@@ -267,6 +281,50 @@ export function saveFarm(): void {
   void room.send('playerSaveFarm', payload)
 }
 
+function applyWorkerServerState(data: {
+  coinsDelta: number
+  workerOutstandingWages: number
+  workerUnpaidDays: number
+  workerLastWageProcessedAt: number
+}): void {
+  playerState.coins = Math.max(0, playerState.coins + data.coinsDelta)
+  playerState.workerOutstandingWages = data.workerOutstandingWages
+  playerState.workerUnpaidDays = data.workerUnpaidDays
+  playerState.workerLastWageProcessedAt = data.workerLastWageProcessedAt
+}
+
+export function requestPayWorkerWages(): void {
+  void room.send('payWorkerWages', {})
+}
+
+function applyDebugWorkerState(data: {
+  coins: number
+  cropsUnlocked: boolean
+  farmerHired: boolean
+  farmerSeeds: CropCount[]
+  workerOutstandingWages: number
+  workerUnpaidDays: number
+  workerLastWageProcessedAt: number
+}): void {
+  playerState.coins = data.coins
+  playerState.cropsUnlocked = data.cropsUnlocked
+  playerState.farmerHired = data.farmerHired
+  playerState.farmerSeeds = arrayToMap(data.farmerSeeds)
+  playerState.workerOutstandingWages = data.workerOutstandingWages
+  playerState.workerUnpaidDays = data.workerUnpaidDays
+  playerState.workerLastWageProcessedAt = data.workerLastWageProcessedAt
+
+  if (data.cropsUnlocked) {
+    removeForSaleSign()
+    unlockFarmerPlots()
+    spawnFarmer()
+  }
+}
+
+export function requestDebugWorkerAction(action: string, amount = 0): void {
+  void room.send('debugWorkerAction', { action, amount })
+}
+
 // ---------------------------------------------------------------------------
 // Schedule auto-save every 60s
 // ---------------------------------------------------------------------------
@@ -335,6 +393,18 @@ export function initSaveService(onLoaded?: () => void): void {
   room.onMessage('beautyLeaderboardLoaded', (data) => {
     if (data.requester !== playerState.wallet) return
     leaderboardCallbacks.onBeautyLeaderboardLoaded?.(data)
+  })
+  room.onMessage('workerStatusUpdated', (data) => {
+    if (data.requester !== playerState.wallet) return
+    applyWorkerServerState(data)
+  })
+  room.onMessage('workerWagePaymentResult', (data) => {
+    if (data.requester !== playerState.wallet) return
+    applyWorkerServerState(data)
+  })
+  room.onMessage('debugWorkerStateUpdated', (data) => {
+    if (data.requester !== playerState.wallet) return
+    applyDebugWorkerState(data)
   })
 
   // Ask server to load our farm (wallet must already be set in playerState)

--- a/src/shared/farmMessages.ts
+++ b/src/shared/farmMessages.ts
@@ -69,6 +69,9 @@ const FarmStateSchema = Schemas.Map({
   farmerHired:      Schemas.Boolean,
   farmerSeeds:      Schemas.Array(CropCountSchema),
   farmerInventory:  Schemas.Array(CropCountSchema),
+  workerOutstandingWages: Schemas.Int,
+  workerUnpaidDays:       Schemas.Int,
+  workerLastWageProcessedAt: Schemas.Int64,
 
   // Dog
   dogOwned: Schemas.Boolean,
@@ -137,6 +140,14 @@ const FarmMessages = {
 
   /** Client → Server: persist current farm state */
   playerSaveFarm: FarmStateSchema,
+
+  /** Client → Server: clear any outstanding worker back-pay */
+  payWorkerWages: Schemas.Map({}),
+
+  debugWorkerAction: Schemas.Map({
+    action: Schemas.String,
+    amount: Schemas.Int,
+  }),
 
   /** Client → Server: fetch a page of known players */
   loadPlayerRegistry: Schemas.Map({ page: Schemas.Int }),
@@ -245,6 +256,37 @@ const FarmMessages = {
     }),
     notificationText: Schemas.String,
   }),
+
+  workerStatusUpdated: Schemas.Map({
+    requester: Schemas.String,
+    coinsDelta: Schemas.Int,
+    workerOutstandingWages: Schemas.Int,
+    workerUnpaidDays: Schemas.Int,
+    workerLastWageProcessedAt: Schemas.Int64,
+  }),
+
+  workerWagePaymentResult: Schemas.Map({
+    requester: Schemas.String,
+    success: Schemas.Boolean,
+    reason: Schemas.String,
+    coinsDelta: Schemas.Int,
+    workerOutstandingWages: Schemas.Int,
+    workerUnpaidDays: Schemas.Int,
+    workerLastWageProcessedAt: Schemas.Int64,
+  }),
+
+  debugWorkerStateUpdated: Schemas.Map({
+    requester: Schemas.String,
+    success: Schemas.Boolean,
+    reason: Schemas.String,
+    coins: Schemas.Int,
+    cropsUnlocked: Schemas.Boolean,
+    farmerHired: Schemas.Boolean,
+    farmerSeeds: Schemas.Array(CropCountSchema),
+    workerOutstandingWages: Schemas.Int,
+    workerUnpaidDays: Schemas.Int,
+    workerLastWageProcessedAt: Schemas.Int64,
+  }),
 }
 
 export const room = registerMessages(FarmMessages)
@@ -324,6 +366,9 @@ export type FarmStatePayload = {
   farmerHired:        boolean
   farmerSeeds:      CropCount[]
   farmerInventory:  CropCount[]
+  workerOutstandingWages: number
+  workerUnpaidDays: number
+  workerLastWageProcessedAt: number
   dogOwned: boolean
   totalCropsHarvested: number
   totalWaterCount:     number

--- a/src/shared/worker.ts
+++ b/src/shared/worker.ts
@@ -24,6 +24,9 @@ export function getWorkerStatus(args: {
   workerUnpaidDays: number
   farmerSeeds: Map<CropType, number>
 }): WorkerStatus {
+  // `workerUnpaidDays` is persisted separately from the derived debt-day count:
+  // outstanding wages drive UI/back-pay totals, while unpaidDays tracks consecutive
+  // missed daily deductions for the 2-day shutdown rule.
   if (!args.farmerHired) return 'inactive'
   if (args.workerUnpaidDays >= 2) return 'idle_unpaid'
   if (getTotalWorkerSeeds(args.farmerSeeds) <= 0) return 'idle_no_seeds'

--- a/src/shared/worker.ts
+++ b/src/shared/worker.ts
@@ -1,0 +1,31 @@
+import { CropType } from '../data/cropData'
+
+export const WORKER_HIRE_COST = 800
+export const WORKER_DAILY_WAGE = 150
+export const WORKER_DAY_MS = 24 * 60 * 60 * 1000
+export const WORKER_DEBUG_ENABLED = false
+
+export type WorkerStatus = 'inactive' | 'active' | 'idle_no_seeds' | 'idle_unpaid'
+
+export function getWorkerDebtDays(outstandingWages: number): number {
+  return Math.max(0, Math.floor(outstandingWages / WORKER_DAILY_WAGE))
+}
+
+export function getTotalWorkerSeeds(seeds: Map<CropType, number>): number {
+  let total = 0
+  seeds.forEach((count) => {
+    if (count > 0) total += count
+  })
+  return total
+}
+
+export function getWorkerStatus(args: {
+  farmerHired: boolean
+  workerUnpaidDays: number
+  farmerSeeds: Map<CropType, number>
+}): WorkerStatus {
+  if (!args.farmerHired) return 'inactive'
+  if (args.workerUnpaidDays >= 2) return 'idle_unpaid'
+  if (getTotalWorkerSeeds(args.farmerSeeds) <= 0) return 'idle_no_seeds'
+  return 'active'
+}

--- a/src/systems/farmerSystem.ts
+++ b/src/systems/farmerSystem.ts
@@ -28,6 +28,8 @@ import { playSeedVfx } from '../systems/seedVfxSystem'
 import { spawnHarvestVfx } from '../systems/harvestVfxSystem'
 import { DIALOG_ICON, BOX_CROPS_ICON } from '../data/imagePaths'
 import { playSound } from './sfxSystem'
+import { COINS_ICON, EXCLAMATION_ICON } from '../data/imagePaths'
+import { getWorkerStatus } from '../shared/worker'
 
 const FARMER_MODEL  = 'assets/scene/Models/Farmer01/Farmer01.glb'
 const HOME_POS       = Vector3.create(44.66, 0, 70.91)
@@ -359,9 +361,23 @@ const FARMER_HEAD_ICON_SIZE = 0.55              // local size (world = Ã—1.2) â€
 
 const inventoryDisplayEntities: Entity[] = []
 let farmerHeadIconEntity: Entity | null = null
+let lastFarmerDisplayKey = ''
 
 export function updateFarmerInventoryDisplay() {
   if (!farmer.entity) return
+
+  // Sum total crops in farmer inventory
+  let totalCount = 0
+  playerState.farmerInventory.forEach((count) => { if (count > 0) totalCount += count })
+
+  const workerStatus = getWorkerStatus({
+    farmerHired: playerState.farmerHired,
+    workerUnpaidDays: playerState.workerUnpaidDays,
+    farmerSeeds: playerState.farmerSeeds,
+  })
+  const displayKey = `${totalCount}|${workerStatus}`
+  if (displayKey === lastFarmerDisplayKey) return
+  lastFarmerDisplayKey = displayKey
 
   // Remove previous count label
   for (const e of inventoryDisplayEntities) {
@@ -369,13 +385,13 @@ export function updateFarmerInventoryDisplay() {
   }
   inventoryDisplayEntities.length = 0
 
-  // Sum total crops in farmer inventory
-  let totalCount = 0
-  playerState.farmerInventory.forEach((count) => { if (count > 0) totalCount += count })
-
-  // Swap head icon between DialogIcon (empty) and BoxCropsIcon (carrying crops)
+  // Swap the head icon to reflect carrying harvest, unpaid wages, or idle state.
   if (farmerHeadIconEntity) {
-    const iconSrc = totalCount > 0 ? BOX_CROPS_ICON : DIALOG_ICON
+    const iconSrc =
+      totalCount > 0 ? BOX_CROPS_ICON
+      : workerStatus === 'idle_unpaid' ? COINS_ICON
+      : workerStatus === 'idle_no_seeds' ? EXCLAMATION_ICON
+      : DIALOG_ICON
     Material.setPbrMaterial(farmerHeadIconEntity, {
       texture:           Material.Texture.Common({ src: iconSrc }),
       emissiveTexture:   Material.Texture.Common({ src: iconSrc }),
@@ -427,8 +443,29 @@ engine.addSystem((dt: number) => {
 
   if (!playerState.farmerHired) return
 
+  const workerStatus = getWorkerStatus({
+    farmerHired: playerState.farmerHired,
+    workerUnpaidDays: playerState.workerUnpaidDays,
+    farmerSeeds: playerState.farmerSeeds,
+  })
+  updateFarmerInventoryDisplay()
+
+  if (workerStatus === 'idle_unpaid') {
+    if (farmer.state !== 'idle' && farmer.state !== 'returning') {
+      farmer.targetPlot = null
+      farmer.actionType = ''
+      startWalkToTarget(HOME_POS)
+      farmer.state = 'returning'
+    }
+
+    if (farmer.state === 'idle') {
+      playAnim('Talk')
+    }
+  }
+
   switch (farmer.state) {
     case 'idle': {
+      if (workerStatus === 'idle_unpaid') return
       farmer.idleTimer -= dt
       if (farmer.idleTimer > 0) return
       const task = pickNextTask()
@@ -464,6 +501,11 @@ engine.addSystem((dt: number) => {
     }
 
     case 'acting': {
+      if (workerStatus === 'idle_unpaid') {
+        startWalkToTarget(HOME_POS)
+        farmer.state = 'returning'
+        return
+      }
       farmer.actionTimer -= dt
       if (farmer.actionTimer > 0) return
       const next = pickNextTask()
@@ -505,6 +547,7 @@ engine.addSystem((dt: number) => {
 
 export function spawnFarmer() {
   if (farmer.entity) return
+  lastFarmerDisplayKey = ''
 
   const farmerEntity = engine.addEntity()
   farmer.entity = farmerEntity
@@ -574,5 +617,6 @@ export function spawnFarmer() {
   })
 
   discoverWaypoints()
+  updateFarmerInventoryDisplay()
   console.log('CozyFarm: Farmer spawned')
 }

--- a/src/systems/farmerSystem.ts
+++ b/src/systems/farmerSystem.ts
@@ -501,11 +501,6 @@ engine.addSystem((dt: number) => {
     }
 
     case 'acting': {
-      if (workerStatus === 'idle_unpaid') {
-        startWalkToTarget(HOME_POS)
-        farmer.state = 'returning'
-        return
-      }
       farmer.actionTimer -= dt
       if (farmer.actionTimer > 0) return
       const next = pickNextTask()

--- a/src/ui/FarmerMenu.tsx
+++ b/src/ui/FarmerMenu.tsx
@@ -6,8 +6,8 @@ import { PanelShell, C } from './PanelShell'
 import { updateFarmerInventoryDisplay } from '../systems/farmerSystem'
 import { triggerCardShake, getShakeOffset } from './cardShakeSystem'
 import { playSound } from '../systems/sfxSystem'
-
-const HIRE_COST = 100
+import { WORKER_DAILY_WAGE, WORKER_HIRE_COST, getWorkerDebtDays, getWorkerStatus } from '../shared/worker'
+import { saveFarm } from '../services/saveService'
 
 // 4 cards per row, 1 row per page
 const FARMER_SEED_PAGE_SIZE = 4
@@ -118,6 +118,12 @@ export const FarmerMenu = () => {
   const availableToGive  = ALL_CROP_TYPES.filter((ct) => (playerState.seeds.get(ct) ?? 0) > 0)
   const collectedEntries = ALL_CROP_TYPES.filter((ct) => (playerState.farmerInventory.get(ct) ?? 0) > 0)
   const hasCollected     = collectedEntries.length > 0
+  const workerState = getWorkerStatus({
+    farmerHired: playerState.farmerHired,
+    workerUnpaidDays: playerState.workerUnpaidDays,
+    farmerSeeds: playerState.farmerSeeds,
+  })
+  const outstandingDays = getWorkerDebtDays(playerState.workerOutstandingWages)
 
   const seedPage  = farmerSeedPage.value
   const seedLast  = Math.max(0, Math.ceil(availableToGive.length / FARMER_SEED_PAGE_SIZE) - 1)
@@ -138,7 +144,7 @@ export const FarmerMenu = () => {
             uiTransform={{ margin: { bottom: 10 } }}
           />
           <Label
-            value="Pay me 100 coins and give me seeds to get started."
+            value={`Pay me ${WORKER_HIRE_COST} coins and give me seeds to get started.`}
             fontSize={26}
             color={C.textMute}
             textAlign="middle-center"
@@ -150,23 +156,27 @@ export const FarmerMenu = () => {
               uiBackground={{ texture: { src: COINS_IMAGE, wrapMode: 'clamp' }, textureMode: 'stretch' }}
             />
             <Label
-              value={`${playerState.coins} / ${HIRE_COST} coins`}
+              value={`${playerState.coins} / ${WORKER_HIRE_COST} coins`}
               fontSize={30}
-              color={playerState.coins >= HIRE_COST ? C.gold : { r: 1, g: 0.4, b: 0.4, a: 1 }}
+              color={playerState.coins >= WORKER_HIRE_COST ? C.gold : { r: 1, g: 0.4, b: 0.4, a: 1 }}
               textAlign="middle-left"
             />
           </UiEntity>
           <Button
-            value={`Hire for ${HIRE_COST} coins`}
-            variant={playerState.coins >= HIRE_COST ? 'primary' : 'secondary'}
-            disabled={playerState.coins < HIRE_COST}
+            value={`Hire for ${WORKER_HIRE_COST} coins`}
+            variant={playerState.coins >= WORKER_HIRE_COST ? 'primary' : 'secondary'}
+            disabled={playerState.coins < WORKER_HIRE_COST}
             fontSize={28}
             uiTransform={{ width: 400, height: 80 }}
             onMouseDown={() => {
-              if (playerState.coins < HIRE_COST) return
+              if (playerState.coins < WORKER_HIRE_COST) return
               playSound('buttonclick')
-              playerState.coins -= HIRE_COST
+              playerState.coins -= WORKER_HIRE_COST
               playerState.farmerHired = true
+              playerState.workerOutstandingWages = 0
+              playerState.workerUnpaidDays = 0
+              playerState.workerLastWageProcessedAt = Date.now()
+              saveFarm()
             }}
           />
         </UiEntity>
@@ -177,6 +187,30 @@ export const FarmerMenu = () => {
         <UiEntity uiTransform={{ flex: 1, flexDirection: 'column', width: '100%' }}>
 
           {/* ─ Collected Harvest ─ */}
+          <UiEntity
+            uiTransform={{ width: '100%', padding: { top: 12, bottom: 12, left: 16, right: 16 }, margin: { bottom: 16 } }}
+            uiBackground={{
+              color:
+                workerState === 'idle_unpaid'
+                  ? { r: 0.24, g: 0.1, b: 0.08, a: 1 }
+                  : workerState === 'idle_no_seeds'
+                    ? { r: 0.14, g: 0.12, b: 0.05, a: 1 }
+                    : { r: 0.08, g: 0.16, b: 0.09, a: 1 },
+            }}
+          >
+            <Label
+              value={
+                workerState === 'idle_unpaid'
+                  ? `Worker unpaid: ${playerState.workerOutstandingWages} coins due (${outstandingDays} day${outstandingDays === 1 ? '' : 's'}). Use the computer to clear wages.`
+                  : workerState === 'idle_no_seeds'
+                    ? `Worker idle: no seeds loaded. Daily wage is ${WORKER_DAILY_WAGE} coins.`
+                    : `Worker active. Daily wage: ${WORKER_DAILY_WAGE} coins.`
+              }
+              fontSize={22}
+              color={workerState === 'idle_unpaid' ? { r: 1, g: 0.72, b: 0.62, a: 1 } : C.textMain}
+              textAlign="middle-left"
+            />
+          </UiEntity>
           <Label value="Collected Harvest" fontSize={26} color={C.textMain} textAlign="top-left" uiTransform={{ margin: { bottom: 10 } }} />
           {hasCollected ? (
             <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', margin: { bottom: 10 } }}>

--- a/src/ui/ShopMenu.tsx
+++ b/src/ui/ShopMenu.tsx
@@ -7,8 +7,10 @@ import { PanelShell, C } from './PanelShell'
 import { tutorialState } from '../game/tutorialState'
 import { triggerCardShake, getShakeOffset } from './cardShakeSystem'
 import { playSound } from '../systems/sfxSystem'
+import { WORKER_DAILY_WAGE, WORKER_DEBUG_ENABLED, getWorkerDebtDays, getWorkerStatus } from '../shared/worker'
+import { requestDebugWorkerAction, requestPayWorkerWages } from '../services/saveService'
 
-const shopTab  = { value: 'seeds' as 'seeds' | 'pets' }
+const shopTab  = { value: 'seeds' as 'seeds' | 'pets' | 'workers' | 'debug' }
 const shopPage = { seeds: 0, pets: 0 }
 
 // 5 cards per row × 2 rows = 10 per page
@@ -139,6 +141,159 @@ const PaginationBar = ({ page, lastPage, onPrev, onNext }: { page: number; lastP
   </UiEntity>
 )
 
+const WorkerPanel = () => {
+  if (!playerState.cropsUnlocked) {
+    return (
+      <UiEntity
+        uiTransform={{ width: '100%', padding: { top: 22, bottom: 22, left: 22, right: 22 } }}
+        uiBackground={{ color: C.rowBg }}
+      >
+        <Label
+          value="Unlock the farm expansion first. The worker payroll terminal becomes available once the worker area is open."
+          fontSize={24}
+          color={C.textMain}
+          textAlign="middle-left"
+        />
+      </UiEntity>
+    )
+  }
+
+  if (!playerState.farmerHired) {
+    return (
+      <UiEntity
+        uiTransform={{ width: '100%', padding: { top: 22, bottom: 22, left: 22, right: 22 } }}
+        uiBackground={{ color: C.rowBg }}
+      >
+        <Label
+          value="No worker hired yet. Talk to the farm worker in the expansion and hire them there."
+          fontSize={24}
+          color={C.textMain}
+          textAlign="middle-left"
+        />
+      </UiEntity>
+    )
+  }
+
+  const workerState = getWorkerStatus({
+    farmerHired: playerState.farmerHired,
+    workerUnpaidDays: playerState.workerUnpaidDays,
+    farmerSeeds: playerState.farmerSeeds,
+  })
+  const outstanding = playerState.workerOutstandingWages
+  const outstandingDays = getWorkerDebtDays(outstanding)
+  const canPay = outstanding > 0 && playerState.coins >= outstanding
+  const statusLabel =
+    workerState === 'idle_unpaid'
+      ? 'Idle (unpaid)'
+      : workerState === 'idle_no_seeds'
+        ? 'Idle (no seeds)'
+        : 'Active'
+
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
+      <UiEntity
+        uiTransform={{ width: '100%', padding: { top: 20, bottom: 20, left: 20, right: 20 }, margin: { bottom: 16 } }}
+        uiBackground={{ color: C.rowBg }}
+      >
+        <Label value="Worker Payroll" fontSize={30} color={C.header} textAlign="middle-left" uiTransform={{ margin: { bottom: 10 } }} />
+        <Label value={`Status: ${statusLabel}`} fontSize={24} color={workerState === 'idle_unpaid' ? C.orange : C.textMain} textAlign="middle-left" />
+        <Label value={`Daily wage: ${WORKER_DAILY_WAGE} coins`} fontSize={22} color={C.textMute} textAlign="middle-left" uiTransform={{ margin: { top: 8 } }} />
+        <Label value={`Outstanding wages: ${outstanding} coins`} fontSize={24} color={outstanding > 0 ? C.orange : C.green} textAlign="middle-left" uiTransform={{ margin: { top: 12 } }} />
+        <Label
+          value={`Missed wage days: ${playerState.workerUnpaidDays}`}
+          fontSize={22}
+          color={playerState.workerUnpaidDays >= 2 ? C.orange : C.textMute}
+          textAlign="middle-left"
+          uiTransform={{ margin: { top: 8 } }}
+        />
+        {outstanding > 0 && (
+          <Label
+            value={
+              playerState.workerUnpaidDays >= 2
+                ? `Worker stopped after ${outstandingDays} unpaid day${outstandingDays === 1 ? '' : 's'}. Clear all back-pay to reactivate them.`
+                : `Back-pay accrued for ${outstandingDays} day${outstandingDays === 1 ? '' : 's'}.`
+            }
+            fontSize={20}
+            color={C.textMute}
+            textAlign="middle-left"
+            uiTransform={{ margin: { top: 8 } }}
+          />
+        )}
+      </UiEntity>
+
+      <UiEntity
+        uiTransform={{ width: '100%', padding: { top: 18, bottom: 18, left: 20, right: 20 } }}
+        uiBackground={{ color: { r: 0.1, g: 0.08, b: 0.05, a: 1 } }}
+      >
+        <Label value={`Balance: ${playerState.coins} coins`} fontSize={24} color={C.gold} textAlign="middle-left" uiTransform={{ margin: { bottom: 12 } }} />
+        {outstanding > 0 && playerState.coins < outstanding && (
+          <Label
+            value="Insufficient balance. Sell crops or collect earnings before paying wages."
+            fontSize={20}
+            color={{ r: 1, g: 0.62, b: 0.52, a: 1 }}
+            textAlign="middle-left"
+            uiTransform={{ margin: { bottom: 14 } }}
+          />
+        )}
+        <Button
+          value={outstanding > 0 ? `Pay ${outstanding} coins` : 'No wages due'}
+          variant={canPay ? 'primary' : 'secondary'}
+          disabled={!canPay}
+          fontSize={26}
+          uiTransform={{ width: 340, height: 76 }}
+          onMouseDown={() => { if (!canPay) return; playSound('buttonclick'); requestPayWorkerWages() }}
+        />
+      </UiEntity>
+    </UiEntity>
+  )
+}
+
+const DebugActionButton = ({ label, onPress, disabled = false }: { label: string; onPress: () => void; disabled?: boolean }) => (
+  <Button
+    value={label}
+    variant={disabled ? 'secondary' : 'primary'}
+    disabled={disabled}
+    fontSize={22}
+    uiTransform={{ width: 260, height: 68, margin: { right: 12, bottom: 12 } }}
+    onMouseDown={() => { if (disabled) return; playSound('buttonclick'); onPress() }}
+  />
+)
+
+const DebugPanel = () => (
+  <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
+    <UiEntity
+      uiTransform={{ width: '100%', padding: { top: 18, bottom: 18, left: 20, right: 20 }, margin: { bottom: 16 } }}
+      uiBackground={{ color: C.rowBg }}
+    >
+      <Label value="Worker Debug" fontSize={30} color={C.header} textAlign="middle-left" uiTransform={{ margin: { bottom: 10 } }} />
+      <Label
+        value="Use this panel to prepare the worker test scenario without editing storage files. It mutates your saved farm state directly on the authoritative server."
+        fontSize={21}
+        color={C.textMain}
+        textAlign="middle-left"
+      />
+      <Label
+        value={`Live snapshot: coins=${playerState.coins}, hired=${playerState.farmerHired ? 'yes' : 'no'}, worker seeds=${Array.from(playerState.farmerSeeds.values()).reduce((sum, count) => sum + count, 0)}, debt=${playerState.workerOutstandingWages}, unpaidDays=${playerState.workerUnpaidDays}`}
+        fontSize={19}
+        color={C.textMute}
+        textAlign="middle-left"
+        uiTransform={{ margin: { top: 10 } }}
+      />
+    </UiEntity>
+
+    <UiEntity uiTransform={{ flexDirection: 'row', flexWrap: 'wrap', width: '100%' }}>
+      <DebugActionButton label="Prepare Worker Test" onPress={() => { requestDebugWorkerAction('setup') }} />
+      <DebugActionButton label="+1000 Coins" onPress={() => { requestDebugWorkerAction('add_coins', 1000) }} />
+      <DebugActionButton label="Set Coins To 0" onPress={() => { requestDebugWorkerAction('set_coins', 0) }} />
+      <DebugActionButton label="Load 20 Worker Seeds" onPress={() => { requestDebugWorkerAction('load_seeds', 20) }} />
+      <DebugActionButton label="Clear Worker Seeds" onPress={() => { requestDebugWorkerAction('clear_seeds') }} />
+      <DebugActionButton label="Advance 1 Day" onPress={() => { requestDebugWorkerAction('advance_days', 1) }} />
+      <DebugActionButton label="Advance 2 Days" onPress={() => { requestDebugWorkerAction('advance_days', 2) }} />
+      <DebugActionButton label="Clear Wage Debt" onPress={() => { requestDebugWorkerAction('clear_debt') }} />
+    </UiEntity>
+  </UiEntity>
+)
+
 export const ShopMenu = () => {
   const tutorialActive = tutorialState.active
 
@@ -174,9 +329,25 @@ export const ShopMenu = () => {
           value="Pets"
           variant={tab === 'pets' ? 'primary' : 'secondary'}
           fontSize={28}
-          uiTransform={{ width: 240, height: 68 }}
+          uiTransform={{ width: 240, height: 68, margin: { right: 12 } }}
           onMouseDown={() => { playSound('buttonclick'); shopTab.value = 'pets' }}
         />
+        <Button
+          value="Workers"
+          variant={tab === 'workers' ? 'primary' : 'secondary'}
+          fontSize={28}
+          uiTransform={{ width: 240, height: 68, margin: { right: 12 } }}
+          onMouseDown={() => { playSound('buttonclick'); shopTab.value = 'workers' }}
+        />
+        {WORKER_DEBUG_ENABLED && (
+          <Button
+            value="Debug"
+            variant={tab === 'debug' ? 'primary' : 'secondary'}
+            fontSize={28}
+            uiTransform={{ width: 240, height: 68 }}
+            onMouseDown={() => { playSound('buttonclick'); shopTab.value = 'debug' }}
+          />
+        )}
       </UiEntity>
 
       {/* Seeds tab */}
@@ -217,6 +388,10 @@ export const ShopMenu = () => {
           <DogCard />
         </UiEntity>
       )}
+
+      {tab === 'workers' && <WorkerPanel />}
+
+      {WORKER_DEBUG_ENABLED && tab === 'debug' && <DebugPanel />}
 
     </PanelShell>
   )

--- a/src/ui/TopHud.tsx
+++ b/src/ui/TopHud.tsx
@@ -3,6 +3,7 @@ import { playerState } from '../game/gameState'
 import { getXpProgress } from '../systems/levelingSystem'
 import { COINS_IMAGE } from '../data/imagePaths'
 import { triggerBtnAnim } from './navAnimSystem'
+import { getWorkerDebtDays } from '../shared/worker'
 
 const C_GOLD = { r: 1, g: 0.88, b: 0.2, a: 1 }
 
@@ -18,6 +19,8 @@ export const TopHud = () => {
   const liveSocialToast = playerState.socialToastText !== '' && Date.now() < playerState.socialToastExpiresAt
   const showSocialToast = DEBUG_SOCIAL_TOAST || liveSocialToast
   const socialToastText = DEBUG_SOCIAL_TOAST ? DEBUG_SOCIAL_TOAST_TEXT : playerState.socialToastText
+  const showWorkerAlert = playerState.farmerHired && playerState.workerOutstandingWages > 0
+  const workerDebtDays = getWorkerDebtDays(playerState.workerOutstandingWages)
 
   if (!DEBUG_SOCIAL_TOAST && !showSocialToast && playerState.socialToastText !== '') {
     playerState.socialToastText = ''
@@ -49,6 +52,32 @@ export const TopHud = () => {
       </UiEntity>
     )}
     {/* ── Leaderboard button (top-right, small) ── */}
+    {showWorkerAlert && (
+      <UiEntity
+        uiTransform={{
+          positionType: 'absolute',
+          position: { top: showSocialToast ? 202 : 140, left: 18 },
+          width: 440,
+          height: 60,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: { left: 14, right: 14 },
+        }}
+        uiBackground={{ color: playerState.workerUnpaidDays >= 2 ? { r: 0.28, g: 0.1, b: 0.08, a: 0.96 } : { r: 0.2, g: 0.13, b: 0.05, a: 0.96 } }}
+      >
+        <Label
+          value={
+            playerState.workerUnpaidDays >= 2
+              ? `Worker unpaid: ${playerState.workerOutstandingWages} coins due (${workerDebtDays} days).`
+              : `Worker wages due: ${playerState.workerOutstandingWages} coins.`
+          }
+          fontSize={18}
+          color={{ r: 1, g: 0.86, b: 0.78, a: 1 }}
+          textAlign="middle-center"
+          uiTransform={{ width: 400, height: 24 }}
+        />
+      </UiEntity>
+    )}
     <UiEntity
       uiTransform={{
         positionType: 'absolute',


### PR DESCRIPTION
## Summary

Implements the worker wage system end-to-end based on `dev-docs/worker-system.md`.

## What changed

- Added authoritative worker wage tracking on the server with persisted fields for:
  - outstanding wages
  - unpaid days
  - last wage processing timestamp
- Implemented automatic wage processing at **150 coins/day**, including offline accrual
- Added unpaid worker behavior:
  - worker stops functioning after **2+ unpaid days**
  - worker stays idle until all back pay is cleared
- Updated worker hire cost to **800 coins** to match the design docs
- Added shared worker helpers/constants for:
  - hire cost
  - daily wage
  - worker status derivation
  - debt-day calculation
- Extended save/load and network schemas so worker wage state persists across reconnects and offline progression
- Added server/client messages for:
  - worker wage state updates
  - wage payment results
- Added a **Workers** tab in the computer UI that shows:
  - current worker status
  - daily wage
  - outstanding wages
  - unpaid day count
  - insufficient balance warning
  - **Pay Wages** action
- Added HUD warning feedback when wages are due
- Updated the farmer UI to surface worker state and unpaid / no-seed conditions
- Updated worker behavior and visual feedback so the NPC:
  - works normally when active
  - idles when out of seeds
  - returns home and stops working when unpaid
  - changes head icon/state feedback depending on condition
- Added a worker debug testing flow in code, then hid/disabled it behind a feature flag so it is not exposed in normal gameplay

Closes #6 