### PR TITLE
Temporarily disable mailbox and neighbors interactions

### DIFF
--- a/src/game/featureFlags.ts
+++ b/src/game/featureFlags.ts
@@ -1,0 +1,1 @@
+export const MAILBOX_FEATURE_ENABLED = false

--- a/src/systems/interactionSetup.ts
+++ b/src/systems/interactionSetup.ts
@@ -21,6 +21,7 @@ import { playSound } from './sfxSystem'
 import { CROP_DATA, CROP_NAMES, CropType } from '../data/cropData'
 import { formatTime } from './growthSystem'
 import { tutorialState } from '../game/tutorialState'
+import { MAILBOX_FEATURE_ENABLED } from '../game/featureFlags'
 import { isVisiting } from '../services/visitService'
 import { ALL_FERTILIZER_TYPES } from '../data/fertilizerData'
 import { requestVisitorWaterPlot, visitorWaterCallbacks } from '../services/socialService'
@@ -253,7 +254,7 @@ function wireLocalFarmInteractives(): void {
   }
 
   const mailbox = getCurrentFarmEntity('Mailbox')
-  if (mailbox) {
+  if (mailbox && MAILBOX_FEATURE_ENABLED) {
     enablePointerOnGltf(mailbox)
     pointerEventsSystem.onPointerDown(
       { entity: mailbox, opts: { button: InputAction.IA_POINTER, hoverText: 'Mailbox & Neighbours', maxDistance: 8 } },

--- a/src/systems/mailboxIndicatorSystem.ts
+++ b/src/systems/mailboxIndicatorSystem.ts
@@ -8,6 +8,7 @@ import {
 } from '@dcl/sdk/ecs'
 import { Color4, Vector3 } from '@dcl/sdk/math'
 import { playerState } from '../game/gameState'
+import { MAILBOX_FEATURE_ENABLED } from '../game/featureFlags'
 import { isVisiting } from '../services/visitService'
 import { getCurrentFarmEntity } from './farmInstances'
 
@@ -73,6 +74,11 @@ function setIndicatorVisible(visible: boolean): void {
 }
 
 function mailboxIndicatorSystem(dt: number): void {
+  if (!MAILBOX_FEATURE_ENABLED) {
+    setIndicatorVisible(false)
+    return
+  }
+
   ensureMailboxIndicator()
   if (!mailboxIndicatorRoot) return
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -24,6 +24,7 @@ import { PigPenPanel }      from './ui/PigPenPanel'
 import { FeedBowlMenu }    from './ui/FeedBowlMenu'
 import { VisitHud }         from './ui/VisitHud'
 import { FarmSelectPanel }  from './ui/FarmSelectPanel'
+import { MAILBOX_FEATURE_ENABLED } from './game/featureFlags'
 
 export function setupUi() {
   ReactEcsRenderer.setUiRenderer(MainUi, { virtualWidth: 1920, virtualHeight: 1080 })
@@ -55,7 +56,7 @@ const MainUi = () => (
 
     {/* World-object menus (continued) */}
     {playerState.activeMenu === 'jukebox'   && <JukeboxMenu />}
-    {playerState.activeMenu === 'mailbox'   && <MailboxMenu />}
+    {MAILBOX_FEATURE_ENABLED && playerState.activeMenu === 'mailbox' && <MailboxMenu />}
     {playerState.activeMenu === 'compost'   && <CompostBinMenu />}
     {playerState.activeMenu === 'chickenCoop' && <ChickenCoopPanel />}
     {playerState.activeMenu === 'pigPen'      && <PigPenPanel />}


### PR DESCRIPTION
## Summary

Temporarily disables the mailbox and neighbors feature for all players.

## Changes

- Added a temporary feature flag to disable the mailbox feature
- Removed mailbox click interaction from the world object
- Prevented the mailbox menu from rendering
- Hid the mailbox indicator while the feature is disabled

## Notes

This is intended as a temporary change and can be reverted by re-enabling the mailbox feature flag.