### PR TITLE
ft/new ui map

### DIFF
--- a/src/game/gameState.ts
+++ b/src/game/gameState.ts
@@ -97,4 +97,13 @@ export const playerState = {
   // Plot group unlock tracking
   unlockedPlotGroups: [] as string[],      // group names purchased via coins
   activePlotGroupName: '',                  // set before opening 'plotGroupUnlock' menu
+  // Runtime-only: shown after a new slot claim, before teleporting the player home
+  farmAssignmentOverlayActive: false,
+  farmAssignmentOverlaySlotId: -1,
+  farmAssignmentOverlayStartedAt: 0,
+  farmAssignmentOverlayDurationMs: 0,
+  // Runtime-only: enables the gameplay HUD/panels only after the player reaches a farm parcel
+  farmGameplayUiReady: false,
+  // Runtime-only: waiting-in-plaza UI state when no farm slot is available
+  plazaMapMinimized: false,
 }

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -38,6 +38,22 @@ function releaseSlot(wallet: string): number | null {
   return slot
 }
 
+function claimSpecificSlot(wallet: string, slotId: number): { success: boolean; reason: string; slotId: number } {
+  const existing = playerSlots.get(wallet)
+  if (existing !== undefined) {
+    return { success: false, reason: 'already_claimed', slotId: existing }
+  }
+  if (slotId < 0 || slotId >= MAX_FARM_SLOTS) {
+    return { success: false, reason: 'invalid_slot', slotId: -1 }
+  }
+  if (activeSlots.has(slotId)) {
+    return { success: false, reason: 'slot_taken', slotId }
+  }
+  activeSlots.set(slotId, wallet)
+  playerSlots.set(wallet, slotId)
+  return { success: true, reason: 'ok', slotId }
+}
+
 function getActiveSlotsPayload() {
   return Array.from({ length: MAX_FARM_SLOTS }, (_, i) => ({
     slotId: i,
@@ -163,6 +179,7 @@ async function cleanupDisconnectedPlayers(): Promise<void> {
     if (slotId !== null) {
       console.log(`[FarmServer] Slot ${slotId} released after presence cleanup`)
       void room.send('farmSlotReleased', { slotId })
+      void room.send('farmSlotsLoaded', { requester: address, slots: getActiveSlotsPayload() })
     }
   }
 }
@@ -532,14 +549,21 @@ export function setupFarmServer(): void {
   room.onMessage('claimFarmSlot', (_data, context) => {
     if (!context) return
     const requester = context.from.toLowerCase()
+    const requestedSlotId = typeof _data.slotId === 'number' ? _data.slotId : -1
+    const result = claimSpecificSlot(requester, requestedSlotId)
+    const slots = getActiveSlotsPayload()
     // Slots are auto-assigned on connect — manual claim is no longer used
     void room.send('farmSlotClaimed', {
       requester,
-      success: false,
-      reason:  'auto_assigned',
-      slotId:  playerSlots.get(requester) ?? -1,
-      slots:   getActiveSlotsPayload(),
+      success: result.success,
+      reason:  result.reason,
+      slotId:  result.slotId,
+      slots,
     })
+    if (!result.success) return
+    void room.send('farmSlotsLoaded', { requester, slots })
+    const visualPayload = buildFarmSlotVisualPayload(result.slotId, requester)
+    if (visualPayload) void room.send('farmSlotVisualUpdated', visualPayload)
   })
 
   // Register the auto-save ECS system

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -552,7 +552,6 @@ export function setupFarmServer(): void {
     const requestedSlotId = typeof _data.slotId === 'number' ? _data.slotId : -1
     const result = claimSpecificSlot(requester, requestedSlotId)
     const slots = getActiveSlotsPayload()
-    // Slots are auto-assigned on connect — manual claim is no longer used
     void room.send('farmSlotClaimed', {
       requester,
       success: result.success,

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -575,7 +575,7 @@ function renderOtherFarmSlot(slotId: number, visual: FarmSlotVisual): void {
 const SOIL_MODEL = 'assets/scene/Models/Soil01/Soil01.glb'
 const SOIL_TRANSPARENT_MODEL = 'assets/scene/Models/Soil01Trasnparent/Soil01Trasnparent.glb'
 
-function teleportToSlot(slotId: number): void {
+export function teleportToSlot(slotId: number): void {
   const pos = slotId >= 0 && slotId < FARM_SPAWN_POSITIONS.length
     ? FARM_SPAWN_POSITIONS[slotId]
     : PLAZA_SPAWN_POSITION

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -43,6 +43,9 @@ import { spawnDog } from '../systems/dogSystem'
 // ---------------------------------------------------------------------------
 const AUTO_SAVE_INTERVAL_MS = 60_000
 const INITIAL_TELEPORT_DELAY_S = 0.25
+const SLOT_ASSIGNMENT_OVERLAY_INTRO_MS = 2_000
+const SLOT_ASSIGNMENT_OVERLAY_PROGRESS_MS = 4_200
+const SLOT_ASSIGNMENT_OVERLAY_TOTAL_MS = SLOT_ASSIGNMENT_OVERLAY_INTRO_MS + SLOT_ASSIGNMENT_OVERLAY_PROGRESS_MS
 const INITIAL_LOAD_RETRY_DELAY_S = 2
 let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
 let farmLoaded = false
@@ -576,6 +579,11 @@ function teleportToSlot(slotId: number): void {
   const pos = slotId >= 0 && slotId < FARM_SPAWN_POSITIONS.length
     ? FARM_SPAWN_POSITIONS[slotId]
     : PLAZA_SPAWN_POSITION
+  playerState.farmAssignmentOverlayActive = false
+  playerState.farmAssignmentOverlaySlotId = -1
+  playerState.farmAssignmentOverlayStartedAt = 0
+  playerState.farmAssignmentOverlayDurationMs = 0
+  playerState.farmGameplayUiReady = slotId >= 0
   void movePlayerTo({ newRelativePosition: pos, cameraTarget: { x: pos.x + 8, y: pos.y, z: pos.z } })
   console.log(`[SaveService] Teleporting to slot ${slotId} → (${pos.x}, ${pos.y}, ${pos.z})`)
 }
@@ -600,6 +608,7 @@ export function initSaveService(onLoaded?: () => void): void {
   let teleportDelayTimer = 0
   let loadRetryTimer = -1
   let initRetryRunning = false
+  let playSlotAssignmentOverlay = false
   let currentLoadRequestId = `load-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
 
   const normalizeAddress = (value: string | null | undefined): string => (value ?? '').toLowerCase()
@@ -608,6 +617,13 @@ export function initSaveService(onLoaded?: () => void): void {
     currentLoadRequestId = `load-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
     void room.send('playerLoadFarm', { requestId: currentLoadRequestId })
     console.log(`[SaveService] playerLoadFarm sent (${currentLoadRequestId})`)
+  }
+
+  function startFarmAssignmentOverlay(slotId: number): void {
+    playerState.farmAssignmentOverlayActive = true
+    playerState.farmAssignmentOverlaySlotId = slotId
+    playerState.farmAssignmentOverlayStartedAt = Date.now()
+    playerState.farmAssignmentOverlayDurationMs = SLOT_ASSIGNMENT_OVERLAY_TOTAL_MS
   }
 
   engine.addSystem((dt) => {
@@ -630,6 +646,14 @@ export function initSaveService(onLoaded?: () => void): void {
 
   function scheduleSingleTeleport(slotId: number): void {
     pendingTeleportSlotId = slotId
+    playerState.farmGameplayUiReady = false
+    if (playSlotAssignmentOverlay) {
+      startFarmAssignmentOverlay(slotId)
+      teleportDelayTimer = SLOT_ASSIGNMENT_OVERLAY_TOTAL_MS / 1000
+      playSlotAssignmentOverlay = false
+      return
+    }
+
     teleportDelayTimer = INITIAL_TELEPORT_DELAY_S
   }
 
@@ -645,12 +669,24 @@ export function initSaveService(onLoaded?: () => void): void {
       return
     }
 
-    const slotChanged = playerState.mySlotId !== mine.slotId
+    const previousSlotId = playerState.mySlotId
+    const slotChanged = previousSlotId !== mine.slotId
+    const shouldShowInitialAssignmentOverlay =
+      !initialPayloadApplied &&
+      previousSlotId < 0 &&
+      mine.slotId >= 0 &&
+      !playerState.farmAssignmentOverlayActive
     playerState.mySlotId = mine.slotId
+    if (playerState.mySlotId >= 0) {
+      playerState.plazaMapMinimized = false
+    }
 
     if (!localFarmInitialized || slotChanged) {
       localFarmInitialized = true  // optimistic lock — reset in catch so retry can recover
       try {
+        if (shouldShowInitialAssignmentOverlay) {
+          playSlotAssignmentOverlay = true
+        }
         setupFarmSlotEntities(playerState.mySlotId >= 0 ? playerState.mySlotId : 0)
         initBeautySpotSystem()
         initAnimalBuildings()
@@ -736,6 +772,12 @@ export function initSaveService(onLoaded?: () => void): void {
   // A player disconnected — hide their farm slot for all clients
   room.onMessage('farmSlotReleased', (data) => {
     if (data.slotId === playerState.mySlotId) return  // own slot, ignore
+    const released = playerState.farmSlots.find((slot) => slot.slotId === data.slotId)
+    if (released) {
+      released.wallet = ''
+      released.displayName = ''
+      released.claimedAt = 0
+    }
     hideFarmSlot(data.slotId)
     console.log(`[SaveService] Farm slot ${data.slotId} hidden — player left`)
   })
@@ -757,6 +799,10 @@ export function initSaveService(onLoaded?: () => void): void {
     const normalizedRequester = normalizeAddress(data.requester)
     const mine = normalizedWallet ? data.slots.find((s) => normalizeAddress(s.wallet) === normalizedWallet) : undefined
     const nextMySlotId = mine ? mine.slotId : playerState.mySlotId
+
+    if (!mine && !playerState.viewingFarm) {
+      playerState.farmGameplayUiReady = false
+    }
 
     for (const slot of data.slots) {
       const isMine = slot.slotId === nextMySlotId && !!normalizedWallet && normalizeAddress(slot.wallet) === normalizedWallet
@@ -796,7 +842,16 @@ export function initSaveService(onLoaded?: () => void): void {
     if (data.success) {
       playerState.mySlotId  = data.slotId
       playerState.farmSlots = data.slots
+      playerState.farmGameplayUiReady = false
+      playerState.plazaMapMinimized = false
       if (playerState.activeMenu === 'farmSelect') playerState.activeMenu = 'none'
+    } else {
+      playerState.farmAssignmentOverlayActive = false
+      playerState.farmAssignmentOverlaySlotId = -1
+      playerState.farmAssignmentOverlayStartedAt = 0
+      playerState.farmAssignmentOverlayDurationMs = 0
+      playerState.farmGameplayUiReady = false
+      playSlotAssignmentOverlay = false
     }
     slotCallbacks.onSlotClaimed?.(data.success, data.reason, data.slots)
   })

--- a/src/systems/inputModifierSystem.ts
+++ b/src/systems/inputModifierSystem.ts
@@ -13,7 +13,7 @@ let menuWasOpen = false
 
 export function setupInputModifierSystem() {
   engine.addSystem(() => {
-    const menuOpen = playerState.activeMenu !== 'none'
+    const menuOpen = playerState.activeMenu !== 'none' || playerState.farmAssignmentOverlayActive
 
     if (menuOpen === menuWasOpen) return
     menuWasOpen = menuOpen

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -25,53 +25,58 @@ import { FeedBowlMenu }    from './ui/FeedBowlMenu'
 import { VisitHud }         from './ui/VisitHud'
 import { FarmSelectPanel }  from './ui/FarmSelectPanel'
 import { MAILBOX_FEATURE_ENABLED } from './game/featureFlags'
+import { FarmAssignmentOverlay } from './ui/FarmAssignmentOverlay'
 
 export function setupUi() {
   ReactEcsRenderer.setUiRenderer(MainUi, { virtualWidth: 1920, virtualHeight: 1080 })
 }
 
-const MainUi = () => (
-  <UiEntity
-    uiTransform={{
-      width: '100%',
-      height: '100%',
-      pointerFilter: 'none',
-    }}
-  >
-    {/* Always-visible chrome */}
-    <TopHud />
-    <VisitHud />
-    <BottomNav />
+const MainUi = () => {
+  const showVisitHud = playerState.viewingFarm !== null
+  const showOwnFarmUi = playerState.viewingFarm === null && playerState.farmGameplayUiReady
+  const waitingForSlot =
+    playerState.viewingFarm === null &&
+    playerState.mySlotId < 0 &&
+    playerState.farmSlots.length > 0
 
-    {/* World-interaction menus (triggered by clicking scene objects) */}
-    {playerState.activeMenu === 'plant'     && <PlantMenu />}
-    {playerState.activeMenu === 'fertilize' && <FertilizeMenu />}
-    {playerState.activeMenu === 'shop'      && <ShopMenu />}
-    {playerState.activeMenu === 'sell'      && <SellMenu />}
-    {playerState.activeMenu === 'unlock'         && <UnlockMenu />}
-    {playerState.activeMenu === 'plotGroupUnlock' && <PlotGroupUnlockMenu />}
-    {(playerState.activeMenu === 'expansion1' || playerState.activeMenu === 'expansion2') && <ExpansionMenu />}
-    {playerState.activeMenu === 'farmer'    && <FarmerMenu />}
-    {playerState.activeMenu === 'npcDialog' && <NpcDialogMenu />}
+  return (
+    <UiEntity
+      uiTransform={{
+        width: '100%',
+        height: '100%',
+        pointerFilter: 'none',
+      }}
+    >
+      {showOwnFarmUi && <TopHud />}
+      {showVisitHud && <VisitHud />}
+      {showOwnFarmUi && playerState.activeMenu !== 'farmSelect' && <BottomNav />}
 
-    {/* World-object menus (continued) */}
-    {playerState.activeMenu === 'jukebox'   && <JukeboxMenu />}
-    {MAILBOX_FEATURE_ENABLED && playerState.activeMenu === 'mailbox' && <MailboxMenu />}
-    {playerState.activeMenu === 'compost'   && <CompostBinMenu />}
-    {playerState.activeMenu === 'chickenCoop' && <ChickenCoopPanel />}
-    {playerState.activeMenu === 'pigPen'      && <PigPenPanel />}
-    {playerState.activeMenu === 'feedBowl'  && <FeedBowlMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'plant'     && <PlantMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'fertilize' && <FertilizeMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'shop'      && <ShopMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'sell'      && <SellMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'unlock'         && <UnlockMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'plotGroupUnlock' && <PlotGroupUnlockMenu />}
+      {showOwnFarmUi && (playerState.activeMenu === 'expansion1' || playerState.activeMenu === 'expansion2') && <ExpansionMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'farmer'    && <FarmerMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'npcDialog' && <NpcDialogMenu />}
 
-    {/* Leaderboard panel */}
-    {playerState.activeMenu === 'leaderboard' && <LeaderboardPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'jukebox'   && <JukeboxMenu />}
+      {showOwnFarmUi && MAILBOX_FEATURE_ENABLED && playerState.activeMenu === 'mailbox' && <MailboxMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'compost'   && <CompostBinMenu />}
+      {showOwnFarmUi && playerState.activeMenu === 'chickenCoop' && <ChickenCoopPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'pigPen'      && <PigPenPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'feedBowl'  && <FeedBowlMenu />}
 
-    {/* Farm selection — shown on first load if player has no slot */}
-    {playerState.activeMenu === 'farmSelect' && <FarmSelectPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'leaderboard' && <LeaderboardPanel />}
 
-    {/* Bottom-nav panels */}
-    {playerState.activeMenu === 'inventory' && <InventoryPanel />}
-    {playerState.activeMenu === 'stats'     && <StatsPanel />}
-    {playerState.activeMenu === 'quests'    && <QuestPanel />}
-    {playerState.activeMenu === 'farm'      && <FarmPanel />}
-  </UiEntity>
-)
+      {(waitingForSlot || playerState.activeMenu === 'farmSelect' || showOwnFarmUi) && <FarmSelectPanel />}
+
+      {showOwnFarmUi && playerState.activeMenu === 'inventory' && <InventoryPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'stats'     && <StatsPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'quests'    && <QuestPanel />}
+      {showOwnFarmUi && playerState.activeMenu === 'farm'      && <FarmPanel />}
+      <FarmAssignmentOverlay />
+    </UiEntity>
+  )
+}

--- a/src/ui/FarmAssignmentOverlay.tsx
+++ b/src/ui/FarmAssignmentOverlay.tsx
@@ -1,0 +1,208 @@
+import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
+import { playerState } from '../game/gameState'
+import { C } from './PanelShell'
+
+const OVERLAY_W = 760
+const OVERLAY_H = 430
+const PROGRESS_W = 540
+const INTRO_HOLD_MS = 2_000
+const PROGRESS_DURATION_MS = 4_200
+
+function getPhaseText(progress: number, farmNumber: number): string {
+  if (progress <= 0) return `Assigning Farm ${farmNumber} to your account`
+  if (progress < 0.34) return `Assigning Farm ${farmNumber} to your account`
+  if (progress < 0.7) return 'Loading crops, tools, and cozy essentials'
+  return `Final checks complete. Sending you to Farm ${farmNumber}`
+}
+
+function pulseValue(offset: number): number {
+  const wave = Math.sin(Date.now() / 220 + offset)
+  return 0.55 + ((wave + 1) * 0.225)
+}
+
+function dotSize(offset: number): number {
+  const wave = Math.sin(Date.now() / 220 + offset)
+  return Math.round(18 + (wave + 1) * 6)
+}
+
+export const FarmAssignmentOverlay = () => {
+  if (!playerState.farmAssignmentOverlayActive) return null
+
+  const startedAt = playerState.farmAssignmentOverlayStartedAt
+  const elapsedMs = Math.max(0, Date.now() - startedAt)
+  const loadElapsedMs = Math.max(0, elapsedMs - INTRO_HOLD_MS)
+  const progress = Math.min(1, loadElapsedMs / PROGRESS_DURATION_MS)
+  const progressPct = Math.round(progress * 100)
+  const farmNumber = Math.max(1, playerState.farmAssignmentOverlaySlotId + 1)
+  const shimmerLeft = Math.max(0, Math.min(PROGRESS_W - 42, Math.round(progress * PROGRESS_W) - 21))
+
+  return (
+    <UiEntity
+      uiTransform={{
+        positionType: 'absolute',
+        position: { top: 0, left: 0 },
+        width: '100%',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerFilter: 'block',
+      }}
+      uiBackground={{ color: { r: 0.03, g: 0.025, b: 0.015, a: 0.9 } }}
+    >
+      <UiEntity
+        uiTransform={{
+          positionType: 'absolute',
+          position: { top: 120, left: 250 },
+          width: 180,
+          height: 180,
+          borderRadius: 90,
+        }}
+        uiBackground={{ color: { r: 0.42, g: 0.22, b: 0.06, a: 0.18 } }}
+      />
+      <UiEntity
+        uiTransform={{
+          positionType: 'absolute',
+          position: { bottom: 110, right: 250 },
+          width: 220,
+          height: 220,
+          borderRadius: 110,
+        }}
+        uiBackground={{ color: { r: 0.16, g: 0.28, b: 0.12, a: 0.16 } }}
+      />
+
+      <UiEntity
+        uiTransform={{
+          width: OVERLAY_W,
+          height: OVERLAY_H,
+          padding: { top: 28, bottom: 34, left: 36, right: 36 },
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+        }}
+        uiBackground={{ color: { r: 0.08, g: 0.065, b: 0.04, a: 0.98 } }}
+      >
+        <UiEntity
+          uiTransform={{
+            width: '100%',
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <UiEntity
+            uiTransform={{
+              width: 164,
+              height: 42,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+            uiBackground={{ color: { r: 0.26, g: 0.19, b: 0.08, a: 1 } }}
+          >
+            <Label value={`FARM ${farmNumber}`} fontSize={20} color={C.header} textAlign="middle-center" />
+          </UiEntity>
+
+          <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center' }}>
+            {[0, 1.9, 3.8].map((offset, i) => {
+              const size = dotSize(offset)
+              const alpha = pulseValue(offset)
+              return (
+                <UiEntity
+                  key={`assign-dot-${i}`}
+                  uiTransform={{
+                    width: size,
+                    height: size,
+                    borderRadius: Math.round(size / 2),
+                    margin: { left: i === 0 ? 0 : 10 },
+                  }}
+                  uiBackground={{ color: { r: 1, g: 0.82, b: 0.34, a: alpha } }}
+                />
+              )
+            })}
+          </UiEntity>
+        </UiEntity>
+
+        <UiEntity uiTransform={{ width: '100%', flexDirection: 'column' }}>
+          <Label
+            value="Preparing your new home"
+            fontSize={46}
+            color={C.textMain}
+            textAlign="middle-left"
+            uiTransform={{ width: '100%', height: 56, margin: { bottom: 10 } }}
+          />
+
+          <Label
+            value={getPhaseText(progress, farmNumber)}
+            fontSize={24}
+            color={{ r: 0.88, g: 0.82, b: 0.72, a: 1 }}
+            textAlign="middle-left"
+            uiTransform={{ width: '100%', height: 30, margin: { bottom: 28 } }}
+          />
+
+          <UiEntity
+            uiTransform={{
+              width: '100%',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              margin: { bottom: 16 },
+            }}
+          >
+            <Label value="Claiming slot" fontSize={18} color={progress >= 0.16 ? C.gold : C.textMute} />
+            <Label value="Loading farm" fontSize={18} color={progress >= 0.5 ? C.gold : C.textMute} />
+            <Label value="Teleporting" fontSize={18} color={progress >= 0.84 ? C.gold : C.textMute} />
+          </UiEntity>
+
+          <UiEntity
+            uiTransform={{ width: PROGRESS_W, height: 20, margin: { bottom: 18 } }}
+            uiBackground={{ color: { r: 0.14, g: 0.11, b: 0.07, a: 1 } }}
+          >
+            <UiEntity
+              uiTransform={{ width: `${progressPct}%`, height: '100%' }}
+              uiBackground={{ color: { r: 0.82, g: 0.60, b: 0.18, a: 1 } }}
+            />
+            <UiEntity
+              uiTransform={{
+                positionType: 'absolute',
+                position: { left: shimmerLeft, top: 0 },
+                width: 42,
+                height: 20,
+              }}
+              uiBackground={{ color: { r: 1, g: 0.92, b: 0.66, a: 0.32 } }}
+            />
+          </UiEntity>
+
+          <UiEntity
+            uiTransform={{
+              width: '100%',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Label
+              value="Setting up your plots, buildings, and spawn point"
+              fontSize={18}
+              color={C.textMute}
+              textAlign="middle-left"
+              uiTransform={{ width: 520, height: 22 }}
+            />
+            <Label
+              value={`${progressPct}%`}
+              fontSize={24}
+              color={C.header}
+              textAlign="middle-right"
+              uiTransform={{ width: 90, height: 28 }}
+            />
+          </UiEntity>
+        </UiEntity>
+
+        <UiEntity
+          uiTransform={{
+            width: '100%',
+            height: 4,
+          }}
+          uiBackground={{ color: { r: 0.38, g: 0.28, b: 0.12, a: 0.75 } }}
+        />
+      </UiEntity>
+    </UiEntity>
+  )
+}

--- a/src/ui/FarmSelectPanel.tsx
+++ b/src/ui/FarmSelectPanel.tsx
@@ -1,33 +1,144 @@
 import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
+import { engine, Transform } from '@dcl/sdk/ecs'
+import { movePlayerTo } from '~system/RestrictedActions'
 import { playerState } from '../game/gameState'
 import { room } from '../shared/farmMessages'
 import type { FarmSlot } from '../shared/farmMessages'
 import { C } from './PanelShell'
 import { playSound } from '../systems/sfxSystem'
+import { FARM_SPAWN_POSITIONS, PLAZA_SPAWN_POSITION } from '../systems/interactionSetup'
 
-// ---------------------------------------------------------------------------
-// Actions
-// ---------------------------------------------------------------------------
+const MAP_TILE_W = 176
+const MAP_TILE_H = 126
+const MAP_ROAD = 16
+const MAP_LAYOUT = [
+  [0, 7, 6],
+  [1, -1, 5],
+  [2, 3, 4],
+] as const
+const MINI_TILE_W = 52
+const MINI_TILE_H = 38
+const MINI_ROAD = 5
+const MAP_WORLD_PADDING = 40
+const BIG_MARKER_SIZE = 20
+const MINI_MARKER_SIZE = 14
+const MAP_PANEL_TOP = 120
+
+type MapSlotMode = 'available' | 'occupied' | 'own'
+type MapViewMode = 'waiting' | 'overview'
+type MarkerPosition = { left: number; top: number }
+
+function getHighlightedSlotId(): number {
+  return playerState.mySlotId
+}
+
+function getSlotMode(slot: FarmSlot, highlightedSlotId: number): MapSlotMode {
+  if (slot.slotId === highlightedSlotId) return 'own'
+  return slot.wallet === '' ? 'available' : 'occupied'
+}
+
+function formatOwnerLabel(slot: FarmSlot): string {
+  const wallet = slot.wallet.trim()
+  const suffix = wallet ? wallet.slice(-4) : ''
+  const name = slot.displayName.trim()
+  if (name && suffix) {
+    const fullLabel = `${name} ${suffix}`
+    if (fullLabel.length <= 13) return fullLabel
+
+    const maxNameLength = Math.max(1, 13 - suffix.length - 1 - 3)
+    return `${name.slice(0, maxNameLength)}... ${suffix}`
+  }
+
+  if (name) {
+    return name.length <= 13 ? name : `${name.slice(0, 10)}...`
+  }
+
+  if (!wallet) return 'Unknown'
+  return wallet.length <= 13 ? wallet : `${wallet.slice(0, 10)}...`
+}
+
+function formatMapOwnerLabel(slot: FarmSlot): string {
+  return formatOwnerLabel(slot)
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+function getWorldMapBounds(): { minX: number; maxX: number; minZ: number; maxZ: number } {
+  const xs = [...FARM_SPAWN_POSITIONS.map((pos) => pos.x), PLAZA_SPAWN_POSITION.x]
+  const zs = [...FARM_SPAWN_POSITIONS.map((pos) => pos.z), PLAZA_SPAWN_POSITION.z]
+  return {
+    minX: Math.min(...xs) - MAP_WORLD_PADDING,
+    maxX: Math.max(...xs) + MAP_WORLD_PADDING,
+    minZ: Math.min(...zs) - MAP_WORLD_PADDING,
+    maxZ: Math.max(...zs) + MAP_WORLD_PADDING,
+  }
+}
+
+function getPlayerMarkerPosition(width: number, height: number): MarkerPosition | null {
+  const playerTransform = Transform.getOrNull(engine.PlayerEntity)
+  if (!playerTransform) return null
+
+  const bounds = getWorldMapBounds()
+  const spanX = Math.max(1, bounds.maxX - bounds.minX)
+  const spanZ = Math.max(1, bounds.maxZ - bounds.minZ)
+  const normalizedX = clamp01((playerTransform.position.x - bounds.minX) / spanX)
+  const normalizedZ = clamp01((playerTransform.position.z - bounds.minZ) / spanZ)
+
+  return {
+    left: normalizedX * width,
+    top: normalizedZ * height,
+  }
+}
 
 export function requestClaimSlot(slotId: number): void {
   playSound('buttonclick')
   void room.send('claimFarmSlot', { slotId })
 }
 
-// ---------------------------------------------------------------------------
-// Slot card
-// ---------------------------------------------------------------------------
+function teleportToFarm(slotId: number, closeMenu = true): void {
+  if (closeMenu) playerState.activeMenu = 'none'
+  playerState.plazaMapMinimized = true
+  const pos = FARM_SPAWN_POSITIONS[slotId]
+  if (!pos) return
+  void movePlayerTo({
+    newRelativePosition: pos,
+    cameraTarget: { x: pos.x + 8, y: pos.y, z: pos.z },
+  })
+}
 
-const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
-  const isMine    = slot.wallet !== '' && slot.wallet === playerState.wallet
-  const isTaken   = slot.wallet !== '' && !isMine
-  const isEmpty   = slot.wallet === ''
+function visitSlot(slot: FarmSlot): void {
+  playSound('buttonclick')
+  teleportToFarm(slot.slotId)
+}
 
-  const borderColor = isMine
-    ? { r: 0.2, g: 0.8, b: 0.3, a: 1 }
-    : isTaken
-      ? { r: 0.4, g: 0.3, b: 0.1, a: 1 }
-      : { r: 0.3, g: 0.5, b: 0.9, a: 1 }
+function openMap(): void {
+  playSound('buttonclick')
+  playerState.activeMenu = 'farmSelect'
+  playerState.plazaMapMinimized = false
+}
+
+function closeMap(viewMode: MapViewMode): void {
+  playSound('buttonclick')
+  if (viewMode === 'waiting') {
+    playerState.plazaMapMinimized = true
+    return
+  }
+  playerState.activeMenu = 'none'
+}
+
+const SlotCard = ({ slot, compact = false }: { key?: number; slot: FarmSlot; compact?: boolean }) => {
+  const isMine = slot.wallet !== '' && slot.wallet === playerState.wallet
+  const isTaken = slot.wallet !== '' && !isMine
+  const isEmpty = slot.wallet === ''
+  const cardWidth = compact ? 274 : 280
+  const cardHeight = compact ? 248 : 320
+  const actionTop = compact ? 12 : 16
+  const titleSize = compact ? 26 : 30
+  const nameSize = compact ? 18 : 20
 
   return (
     <UiEntity
@@ -35,34 +146,31 @@ const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        width: 280,
-        height: 320,
-        margin: { right: 24 },
-        padding: { top: 24, bottom: 24, left: 20, right: 20 },
+        width: cardWidth,
+        height: cardHeight,
+        margin: { right: compact ? 14 : 24, bottom: compact ? 14 : 0 },
+        padding: { top: compact ? 18 : 24, bottom: compact ? 18 : 24, left: 20, right: 20 },
       }}
       uiBackground={{ color: C.rowBg }}
     >
-      {/* Farm number */}
       <Label
         value={`Farm ${slot.slotId + 1}`}
-        fontSize={30}
+        fontSize={titleSize}
         color={C.header}
         textAlign="middle-center"
         uiTransform={{ margin: { bottom: 12 } }}
       />
 
-      {/* Status */}
       {isMine && (
-        <Label value="Your Farm" fontSize={20} color={{ r: 0.2, g: 0.9, b: 0.3, a: 1 }} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
+        <Label value="Your Farm" fontSize={nameSize} color={{ r: 0.2, g: 0.9, b: 0.3, a: 1 }} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
       )}
       {isTaken && (
-        <Label value={slot.displayName || slot.wallet.slice(0, 10)} fontSize={20} color={C.orange} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
+        <Label value={formatOwnerLabel(slot)} fontSize={nameSize} color={C.orange} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
       )}
       {isEmpty && (
-        <Label value="Available" fontSize={20} color={C.textMute} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
+        <Label value="Available" fontSize={nameSize} color={C.textMute} textAlign="middle-center" uiTransform={{ margin: { bottom: 8 } }} />
       )}
 
-      {/* Action button */}
       {isEmpty && (
         <UiEntity
           uiTransform={{
@@ -70,7 +178,7 @@ const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
             height: 60,
             alignItems: 'center',
             justifyContent: 'center',
-            margin: { top: 16 },
+            margin: { top: actionTop },
           }}
           uiBackground={{ color: { r: 0.15, g: 0.4, b: 0.8, a: 1 } }}
           onMouseDown={() => requestClaimSlot(slot.slotId)}
@@ -86,10 +194,13 @@ const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
             height: 60,
             alignItems: 'center',
             justifyContent: 'center',
-            margin: { top: 16 },
+            margin: { top: actionTop },
           }}
           uiBackground={{ color: { r: 0.15, g: 0.5, b: 0.2, a: 1 } }}
-          onMouseDown={() => { playerState.activeMenu = 'none' }}
+          onMouseDown={() => {
+            playSound('buttonclick')
+            teleportToFarm(slot.slotId)
+          }}
         >
           <Label value="Enter Farm" fontSize={24} color={C.textMain} textAlign="middle-center" />
         </UiEntity>
@@ -102,18 +213,15 @@ const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
             height: 60,
             alignItems: 'center',
             justifyContent: 'center',
-            margin: { top: 16 },
+            margin: { top: actionTop },
           }}
           uiBackground={{ color: { r: 0.3, g: 0.2, b: 0.05, a: 1 } }}
-          onMouseDown={() => {
-            // TODO: visit this farm (wire into visitService)
-          }}
+          onMouseDown={() => visitSlot(slot)}
         >
           <Label value="Visit" fontSize={24} color={C.textMain} textAlign="middle-center" />
         </UiEntity>
       )}
 
-      {/* Claimed date for occupied slots */}
       {!isEmpty && slot.claimedAt > 0 && (
         <Label
           value={`Since ${new Date(slot.claimedAt).toLocaleDateString()}`}
@@ -127,16 +235,406 @@ const SlotCard = ({ slot }: { key?: number; slot: FarmSlot }) => {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Main panel — full-screen overlay, no close button
-// (dismissed only by claiming a slot or entering your own farm)
-// ---------------------------------------------------------------------------
+const MapFarmTile = ({
+  slot,
+  mode,
+  viewMode,
+}: {
+  key?: string
+  slot: FarmSlot
+  mode: MapSlotMode
+  viewMode: MapViewMode
+}) => (
+  <UiEntity
+    uiTransform={{
+      width: MAP_TILE_W,
+      height: MAP_TILE_H,
+      padding: { top: 14, bottom: 14, left: 14, right: 14 },
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+    }}
+    uiBackground={{
+      color:
+        mode === 'own' ? { r: 0.56, g: 0.47, b: 0.08, a: 1 } :
+        mode === 'available' ? { r: 0.16, g: 0.28, b: 0.52, a: 1 } :
+        { r: 0.17, g: 0.42, b: 0.16, a: 1 },
+    }}
+  >
+    <UiEntity uiTransform={{ width: '100%', alignItems: 'flex-start' }}>
+      <Label
+        value={`Farm ${slot.slotId + 1}`}
+        fontSize={20}
+        color={C.header}
+        textAlign="middle-left"
+        uiTransform={{ width: '100%', height: 22 }}
+      />
+    </UiEntity>
+
+    <UiEntity uiTransform={{ width: '100%', height: 38, justifyContent: 'center' }}>
+      <Label
+        value={mode === 'available' ? 'Available Slot' : formatMapOwnerLabel(slot)}
+        fontSize={19}
+        color={C.textMain}
+        textAlign="middle-left"
+        uiTransform={{ width: '100%', height: 22 }}
+      />
+    </UiEntity>
+
+    <UiEntity uiTransform={{ width: '100%', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+      {mode === 'available' && viewMode === 'waiting' && (
+        <UiEntity
+          uiTransform={{
+            width: 92,
+            height: 34,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          uiBackground={{ color: { r: 0.07, g: 0.09, b: 0.07, a: 0.95 } }}
+          onMouseDown={() => requestClaimSlot(slot.slotId)}
+        >
+          <Label value="Claim" fontSize={16} color={C.textMain} textAlign="middle-center" uiTransform={{ width: 56, height: 18 }} />
+        </UiEntity>
+      )}
+      {mode === 'occupied' && (
+        <UiEntity
+          uiTransform={{
+            width: 92,
+            height: 34,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          uiBackground={{ color: { r: 0.07, g: 0.09, b: 0.07, a: 0.95 } }}
+          onMouseDown={() => visitSlot(slot)}
+        >
+          <Label value="Visit" fontSize={16} color={C.textMain} textAlign="middle-center" uiTransform={{ width: 56, height: 18 }} />
+        </UiEntity>
+      )}
+      {mode === 'own' && (
+        <UiEntity
+          uiTransform={{
+            width: 92,
+            height: 34,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          uiBackground={{ color: { r: 0.22, g: 0.18, b: 0.05, a: 0.95 } }}
+          onMouseDown={() => {
+            playSound('buttonclick')
+            teleportToFarm(slot.slotId)
+          }}
+        >
+          <Label value="Home" fontSize={16} color={C.textMain} textAlign="middle-center" uiTransform={{ width: 56, height: 18 }} />
+        </UiEntity>
+      )}
+    </UiEntity>
+  </UiEntity>
+)
+
+const MapPlazaTile = () => (
+  <UiEntity
+    uiTransform={{
+      width: MAP_TILE_W,
+      height: MAP_TILE_H,
+      padding: { top: 12, bottom: 12, left: 12, right: 12 },
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }}
+    uiBackground={{ color: { r: 0.17, g: 0.14, b: 0.10, a: 1 } }}
+  >
+    <UiEntity
+      uiTransform={{
+        width: 64,
+        height: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      uiBackground={{ color: { r: 0.26, g: 0.20, b: 0.12, a: 1 } }}
+    >
+      <Label value="PLAZA" fontSize={11} color={C.header} textAlign="middle-center" uiTransform={{ width: 46, height: 12 }} />
+    </UiEntity>
+
+    <UiEntity uiTransform={{ width: '100%', alignItems: 'center', justifyContent: 'center' }}>
+      <Label
+        value="Central Plaza"
+        fontSize={20}
+        color={C.textMain}
+        textAlign="middle-center"
+        uiTransform={{ width: '100%', height: 20 }}
+      />
+    </UiEntity>
+
+    <UiEntity
+      uiTransform={{
+        width: 96,
+        height: 10,
+      }}
+      uiBackground={{ color: { r: 0.03, g: 0.03, b: 0.03, a: 1 } }}
+    />
+  </UiEntity>
+)
+
+const MiniMapFarmTile = ({ mode }: { key?: string; mode: MapSlotMode }) => (
+  <UiEntity
+    uiTransform={{ width: MINI_TILE_W, height: MINI_TILE_H }}
+    uiBackground={{
+      color:
+        mode === 'own' ? { r: 0.56, g: 0.47, b: 0.08, a: 1 } :
+        mode === 'available' ? { r: 0.16, g: 0.28, b: 0.52, a: 1 } :
+        { r: 0.17, g: 0.42, b: 0.16, a: 1 },
+    }}
+  />
+)
+
+const MiniMapPlazaTile = () => (
+  <UiEntity
+    uiTransform={{
+      width: MINI_TILE_W,
+      height: MINI_TILE_H,
+      alignItems: 'center',
+      justifyContent: 'center',
+    }}
+    uiBackground={{ color: { r: 0.17, g: 0.14, b: 0.10, a: 1 } }}
+  />
+)
+
+const MapPlayerMarker = ({
+  marker,
+  size,
+  inset,
+}: {
+  marker: MarkerPosition | null
+  size: number
+  inset: number
+}) => {
+  if (!marker) return null
+
+  return (
+    <UiEntity
+      uiTransform={{
+        positionType: 'absolute',
+        position: {
+          left: inset + marker.left - size / 2,
+          top: inset + marker.top - size / 2,
+        },
+        width: size,
+        height: size,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Label
+      value="•"
+        fontSize={size * 2.2}
+        color={{ r: 0.88, g: 0.18, b: 0.12, a: 1 }}
+        textAlign="middle-center"
+        uiTransform={{ width: size, height: size }}
+      />
+    </UiEntity>
+  )
+}
 
 export const FarmSelectPanel = () => {
-  const slots        = playerState.farmSlots
-  const allFull      = slots.length > 0 && slots.every((s) => s.wallet !== '')
-  const mySlot       = slots.find((s) => s.wallet === playerState.wallet)
-  const isLoading    = slots.length === 0
+  const slots = playerState.farmSlots
+  const allFull = slots.length > 0 && slots.every((s) => s.wallet !== '')
+  const mySlot = slots.find((s) => s.wallet === playerState.wallet)
+  const isLoading = slots.length === 0
+  const viewMode: MapViewMode | null =
+    !mySlot && slots.length > 0 ? 'waiting'
+    : mySlot ? 'overview'
+    : null
+
+  if (viewMode) {
+    const slotById = new Map(slots.map((slot) => [slot.slotId, slot]))
+    const highlightedSlotId = getHighlightedSlotId()
+    const mapCardWidth = MAP_TILE_W * 3 + MAP_ROAD * 2 + 24
+    const mapCardHeight = MAP_TILE_H * 3 + MAP_ROAD * 2 + 24
+    const mapGridWidth = MAP_TILE_W * 3 + MAP_ROAD * 2
+    const mapGridHeight = MAP_TILE_H * 3 + MAP_ROAD * 2
+    const miniMapWidth = MINI_TILE_W * 3 + MINI_ROAD * 2 + 12
+    const miniMapHeight = MINI_TILE_H * 3 + MINI_ROAD * 2 + 12
+    const miniGridWidth = MINI_TILE_W * 3 + MINI_ROAD * 2
+    const miniGridHeight = MINI_TILE_H * 3 + MINI_ROAD * 2
+    const bigMarker = getPlayerMarkerPosition(mapGridWidth, mapGridHeight)
+    const miniMarker = getPlayerMarkerPosition(miniGridWidth, miniGridHeight)
+    const showMiniMap =
+      viewMode === 'waiting'
+        ? playerState.plazaMapMinimized
+        : playerState.activeMenu !== 'farmSelect'
+    const headerTitle = viewMode === 'waiting' ? 'Plaza Map' : 'Neighborhood Map'
+    const headerLine1 = viewMode === 'waiting'
+      ? (allFull
+        ? 'All 8 farms are currently occupied. Please wait for a slot to open.'
+        : 'A farm slot is available. Claim it from the map below.')
+      : `Farm ${mySlot!.slotId + 1} is yours. Yellow marks your parcel.`
+    const headerLine2 = viewMode === 'waiting'
+      ? (allFull
+        ? "But don't worry, you can still visit your friends' farms."
+        : 'Blue parcels are free to claim. Green parcels are occupied.')
+      : 'Tap a green farm to visit. Tap Home to return to your parcel.'
+
+    if (showMiniMap) {
+      return (
+        <UiEntity
+          uiTransform={{
+            positionType: 'absolute',
+            position: { top: 220, right: 220 },
+            width: miniMapWidth + 20,
+            height: miniMapHeight + 58,
+            padding: { top: 10, bottom: 10, left: 10, right: 10 },
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            pointerFilter: 'block',
+          }}
+          uiBackground={{ color: { r: 0.09, g: 0.07, b: 0.04, a: 0.94 } }}
+          onMouseDown={openMap}
+        >
+          <Label
+            value={viewMode === 'waiting' ? 'Plaza Map' : 'Map'}
+            fontSize={18}
+            color={C.header}
+            textAlign="middle-center"
+            uiTransform={{ width: miniMapWidth, height: 16 }}
+          />
+          <UiEntity
+            uiTransform={{
+              width: miniMapWidth,
+              height: miniMapHeight,
+              padding: { top: 6, bottom: 6, left: 6, right: 6 },
+              flexDirection: 'column',
+              justifyContent: 'space-between',
+            }}
+            uiBackground={{ color: { r: 0.03, g: 0.03, b: 0.03, a: 1 } }}
+          >
+            {MAP_LAYOUT.map((row, rowIndex) => (
+              <UiEntity
+                key={`mini-row-${rowIndex}`}
+                uiTransform={{
+                  width: '100%',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                }}
+              >
+                {row.map((slotId, colIndex) =>
+                  slotId === -1
+                    ? <MiniMapPlazaTile key={`mini-plaza-${rowIndex}-${colIndex}`} />
+                    : <MiniMapFarmTile
+                        key={`mini-slot-${slotId}`}
+                        mode={getSlotMode(slotById.get(slotId)!, highlightedSlotId)}
+                      />
+                )}
+              </UiEntity>
+            ))}
+            <MapPlayerMarker marker={miniMarker} size={MINI_MARKER_SIZE} inset={6} />
+          </UiEntity>
+          <Label
+            value="Open"
+            fontSize={14}
+            color={C.textMute}
+            textAlign="middle-center"
+            uiTransform={{ width: miniMapWidth, height: 14 }}
+          />
+        </UiEntity>
+      )
+    }
+
+    return (
+      <UiEntity
+        uiTransform={{
+          positionType: 'absolute',
+          position: { top: 0, left: 0 },
+          width: '100%',
+          height: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerFilter: 'none',
+        }}
+      >
+          <UiEntity
+            uiTransform={{
+              positionType: 'absolute',
+              position: { top: MAP_PANEL_TOP },
+            width: 760,
+            height: 730,
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+            padding: { top: 22, bottom: 22, left: 22, right: 22 },
+            pointerFilter: 'block',
+          }}
+          uiBackground={{ color: { r: 0.09, g: 0.07, b: 0.04, a: 0.96 } }}
+        >
+          <Label
+            value={headerTitle}
+            fontSize={34}
+            color={C.header}
+            textAlign="middle-center"
+            uiTransform={{ width: 620, height: 34, margin: { bottom: 10 } }}
+          />
+          <UiEntity
+            uiTransform={{
+              positionType: 'absolute',
+              position: { top: 18, right: 18 },
+              width: 68,
+              height: 34,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+            uiBackground={{ color: { r: 0.20, g: 0.08, b: 0.04, a: 1 } }}
+            onMouseDown={() => closeMap(viewMode)}
+          >
+            <Label value="Close" fontSize={16} color={C.orange} textAlign="middle-center" uiTransform={{ width: 52, height: 20 }} />
+          </UiEntity>
+          <Label
+            value={headerLine1}
+            fontSize={21}
+            color={viewMode === 'waiting' ? C.orange : C.header}
+            textAlign="middle-center"
+            uiTransform={{ width: 620, height: 72, margin: { bottom: 6 } }}
+          />
+          <Label
+            value={headerLine2}
+            fontSize={18}
+            color={C.textMute}
+            textAlign="middle-center"
+            uiTransform={{ width: 620, height: 60, margin: { bottom: 12 } }}
+          />
+          <UiEntity
+            uiTransform={{
+              width: mapCardWidth,
+              height: mapCardHeight,
+              padding: { top: 12, bottom: 12, left: 12, right: 12 },
+              flexDirection: 'column',
+              justifyContent: 'space-between',
+            }}
+            uiBackground={{ color: { r: 0.03, g: 0.03, b: 0.03, a: 1 } }}
+          >
+            {MAP_LAYOUT.map((row, rowIndex) => (
+              <UiEntity
+                key={`map-row-${rowIndex}`}
+                uiTransform={{
+                  width: '100%',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                }}
+              >
+                {row.map((slotId, colIndex) => {
+                  if (slotId === -1) {
+                    return <MapPlazaTile key={`plaza-${rowIndex}-${colIndex}`} />
+                  }
+
+                  const slot = slotById.get(slotId)
+                  return slot ? <MapFarmTile key={`map-slot-${slotId}`} slot={slot} mode={getSlotMode(slot, highlightedSlotId)} viewMode={viewMode} /> : <UiEntity key={`empty-${slotId}`} />
+                })}
+              </UiEntity>
+            ))}
+            <MapPlayerMarker marker={bigMarker} size={BIG_MARKER_SIZE} inset={12} />
+          </UiEntity>
+        </UiEntity>
+      </UiEntity>
+    )
+  }
 
   return (
     <UiEntity
@@ -169,13 +667,21 @@ export const FarmSelectPanel = () => {
           uiTransform={{ margin: { bottom: 32 } }}
         />
       ) : allFull ? (
-        <Label
-          value="All farms are taken. You can visit them below."
-          fontSize={24}
-          color={C.orange}
-          textAlign="middle-center"
-          uiTransform={{ margin: { bottom: 32 } }}
-        />
+        <UiEntity uiTransform={{ alignItems: 'center', margin: { bottom: 32 } }}>
+          <Label
+            value="All 8 farms are currently occupied. Please wait for a slot to open."
+            fontSize={24}
+            color={C.orange}
+            textAlign="middle-center"
+            uiTransform={{ margin: { bottom: 10 } }}
+          />
+          <Label
+            value="But don't worry, you can still visit your friends' farms."
+            fontSize={22}
+            color={C.textMute}
+            textAlign="middle-center"
+          />
+        </UiEntity>
       ) : (
         <Label
           value="Choose a farm to start your journey!"

--- a/src/ui/FarmSelectPanel.tsx
+++ b/src/ui/FarmSelectPanel.tsx
@@ -1,16 +1,17 @@
 import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
 import { engine, Transform } from '@dcl/sdk/ecs'
-import { movePlayerTo } from '~system/RestrictedActions'
 import { playerState } from '../game/gameState'
 import { room } from '../shared/farmMessages'
 import type { FarmSlot } from '../shared/farmMessages'
 import { C } from './PanelShell'
 import { playSound } from '../systems/sfxSystem'
 import { FARM_SPAWN_POSITIONS, PLAZA_SPAWN_POSITION } from '../systems/interactionSetup'
+import { teleportToSlot } from '../services/saveService'
 
 const MAP_TILE_W = 176
 const MAP_TILE_H = 126
 const MAP_ROAD = 16
+// 3×3 grid encoding 8 farm slots + central plaza (-1). Matches server MAX_FARM_SLOTS = 8.
 const MAP_LAYOUT = [
   [0, 7, 6],
   [1, -1, 5],
@@ -22,7 +23,7 @@ const MINI_ROAD = 5
 const MAP_WORLD_PADDING = 40
 const BIG_MARKER_SIZE = 20
 const MINI_MARKER_SIZE = 14
-const MAP_PANEL_TOP = 120
+const MAP_PANEL_TOP = 190
 
 type MapSlotMode = 'available' | 'occupied' | 'own'
 type MapViewMode = 'waiting' | 'overview'
@@ -102,12 +103,7 @@ export function requestClaimSlot(slotId: number): void {
 function teleportToFarm(slotId: number, closeMenu = true): void {
   if (closeMenu) playerState.activeMenu = 'none'
   playerState.plazaMapMinimized = true
-  const pos = FARM_SPAWN_POSITIONS[slotId]
-  if (!pos) return
-  void movePlayerTo({
-    newRelativePosition: pos,
-    cameraTarget: { x: pos.x + 8, y: pos.y, z: pos.z },
-  })
+  teleportToSlot(slotId)
 }
 
 function visitSlot(slot: FarmSlot): void {
@@ -516,14 +512,12 @@ export const FarmSelectPanel = () => {
                   justifyContent: 'space-between',
                 }}
               >
-                {row.map((slotId, colIndex) =>
-                  slotId === -1
-                    ? <MiniMapPlazaTile key={`mini-plaza-${rowIndex}-${colIndex}`} />
-                    : <MiniMapFarmTile
-                        key={`mini-slot-${slotId}`}
-                        mode={getSlotMode(slotById.get(slotId)!, highlightedSlotId)}
-                      />
-                )}
+                {row.map((slotId, colIndex) => {
+                  if (slotId === -1) return <MiniMapPlazaTile key={`mini-plaza-${rowIndex}-${colIndex}`} />
+                  const slot = slotById.get(slotId)
+                  if (!slot) return <UiEntity key={`mini-empty-${slotId}`} />
+                  return <MiniMapFarmTile key={`mini-slot-${slotId}`} mode={getSlotMode(slot, highlightedSlotId)} />
+                })}
               </UiEntity>
             ))}
             <MapPlayerMarker marker={miniMarker} size={MINI_MARKER_SIZE} inset={6} />


### PR DESCRIPTION
Summary:
This PR replaces the old flat slot-card list with a full neighborhood map UI for the farm selection system in Cozy Farm. It introduces two main visual modes and a new assignment overlay.

Key Changes:

• Interactive Map View (3×3 grid): Farm slots are now displayed as tiles in a spatial grid layout with a central "Plaza" tile. Color-coded by status: yellow = your farm, blue = available, green = occupied by another player. Each tile has contextual actions (Claim / Visit / Home).

• Mini-map widget: When the full map is closed, a compact mini-map appears in the top-right corner showing the same grid with simplified tiles and a red player position marker. Clicking it opens the full map.

• Farm Assignment Overlay (FarmAssignmentOverlay.tsx): A new full-screen animated overlay that plays when a player first claims a slot. Shows a progress bar with three phases ("Claiming slot" → "Loading farm" → "Teleporting"), pulsing dot animations, and phase-dependent status text. Blocks input during the ~6.2s animation before teleporting.

• Specific slot claiming: Server now supports claimSpecificSlot() — players choose which farm they want from the map instead of getting auto-assigned. Also broadcasts updated slot data after a slot is released.

• Conditional UI rendering: The main HUD (ui.tsx) now gates all gameplay panels behind farmGameplayUiReady, so menus/HUD only appear after the player reaches their farm parcel. Players waiting in the plaza (no slot) see the map in "waiting" mode.

• Teleport & visit wiring: "Enter Farm" and "Visit" buttons are now fully functional — they trigger movePlayerTo with the correct farm spawn position and camera target.

• Player position tracking: Both mini-map and full map show a real-time red dot for the player's world position, calculated by normalizing Transform coordinates against farm spawn bounds.

• Owner label formatting: Truncates long display names with wallet suffix for clean tile labels (max 13 chars).