### PR TITLE
fix: dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "dcl-project",
       "version": "1.0.0",
       "devDependencies": {
-        "@dcl/js-runtime": "^7.22.6-25321038582.commit-63ddb3f",
-        "@dcl/sdk": "^7.22.6-25321038582.commit-63ddb3f"
+        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/sdk": "7.21.1-22918726402.commit-ee210ee"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -24,9 +24,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -70,14 +70,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -91,15 +91,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/crypto": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.6.0.tgz",
-      "integrity": "sha512-00DGe0eHq7TJlZmaa6BMy2XnhrUkkmWdGY/oVGTJdjSHFHvRk9DBgmrPeiwB5EFFlHb5hWKysJ5UwvhDU9JTtA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/schemas": "^25.2.0",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@dcl/crypto/node_modules/@dcl/schemas": {
@@ -116,9 +119,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-ZNi2UILQvrW8drmxivtlh1x9DCDkefDGUmIDERMILH8lKAjjgYkgJ9Q+fXoJmv6J1FY0x44m45OYm8XHNG+TfA==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-qR7SoIt9ji+5Wy2SL4s2K2fTmbnTWUCaALeEAmfzKhRA/YCs6B2jm1qvuLEWkiGx5qOZNH0R0K0IiN13Gce/GA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -229,9 +232,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.15.2.tgz",
-      "integrity": "sha512-RQPcos1LvV62LuxJgw9U9+hAWPRVPrvxw8KCbhtZdpDZAdlNxPxzEgNdsEaltXWcE9V5nbeTHwxlM5V0EAQnYA==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.15.3.tgz",
+      "integrity": "sha512-Nmd2EyrWXqHod3v7f+Z4A8v2rhC+81knI2mRWS5RBv56krdqS0NIsj5R9SbXlskEB23+JUQbXtl6FVbVCrpMhQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -244,9 +247,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/ecs": {
-      "version": "7.23.1",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.23.1.tgz",
-      "integrity": "sha512-tRT0cw5dmybzB24bonJ8ZdSz3cb6Eu90BscNWe9R4yvoyaGue/PFx3EtUxJvN5AFI409PK+Lvr7n2uDQF3gRvQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.23.3.tgz",
+      "integrity": "sha512-W0OqWDfhsI8SnUn4Hsxh5FG1LEcIyAHQlf/chP6EkMhKIhhFHOsRwYGQJCkOOEXaB6wUuyPN2wl2xTpTn8RHtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
@@ -262,9 +265,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,9 +303,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -353,16 +356,16 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-9AKi8Zpr9a1t2zuRwzwXJEWb902JR9qNWo2UIlHqLYAJIJ4+O1dF2H6NEbJsnji/oJq00TSsJwN3kavMFBVtSg==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Q088hyE1Bm8Wpxx98BRVJYeRlmZ7ty2E/oCX20Xfdo1uGlgSZ5KHLQMuNDDzi9CSwZj8oeUrzJPLq5py+mvMGQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.15.2.tgz",
-      "integrity": "sha512-aYUCfcQp0eMCZfDt+iV2wMBl3oVMsl68uMz6jSVpnfTFqEqMlCmfeh0uZTr/eVMkSvQl8JUSrsKE1aGSE//bNw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.15.0.tgz",
+      "integrity": "sha512-YwRvHzfyyHq2mj17ceRMjXEeMhPEamr+Fq1nM8/+G2OjujmofFnoQzri37zIBOJunYeEHaUP+ftoNoHgRTx73Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -399,9 +402,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-24513367586.commit-0ed6dc3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-24513367586.commit-0ed6dc3.tgz",
-      "integrity": "sha512-UOLtMPwyyhVSwzJIWMaDdN3czUQ603+ZNrU4JXSlNkbJOxV5FKHCfkUynupAUWr0zu9XtMQ5+zvGkWOoNwRF5A==",
+      "version": "1.0.0-22669986637.commit-fb11819",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-22669986637.commit-fb11819.tgz",
+      "integrity": "sha512-/N6EB6wjBbRFvVwZOW5++KIPKSQC7nxoPlIEfRYmR8Ysi1NzPCKHHftg9NiswfTRkyOPcjbaUtq9fT8jkjiTjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -430,13 +433,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-V7hXJ57GAk5Opz2GGN7h2zaU075EJJQA402rJI7c+q+w6HS30X15SJPBUGznTpLcZIBxVQGNSn0QDylf+VqXuA==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-4POOdsqhPekDfd/YiGZ7ZriPxdeD042YkpZR0gGNw1o5e+teYK2faKxwNYBN+9aGIE6DaoqXpRxi8FDiUZiEGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -465,37 +468,37 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-ggbInawjUjqiax23WoGFQ3P2+4nMJxM5So2DYSwfYxrZi6e6WRWq7UpKwpGBM9AASlKYxpzMkpZjRTJN+seCYw==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Z5EbZCzQEGUlhZTSo9x42gN8e02PdPE0s1JXKFp863Mzhc6uAnmmJDSe95bQ8VvfJuQcmAeD8nDCbYlo/NC2cQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.22.6-25321038582.commit-63ddb3f",
-        "@dcl/react-ecs": "7.22.6-25321038582.commit-63ddb3f",
-        "@dcl/sdk-commands": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/react-ecs": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/sdk-commands": "7.21.1-22918726402.commit-ee210ee",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-dJRBoFJfZucut/eiBxeF1U+us1g6Uydi17jND2fXqir+9kXW9TEtb28g8mCXBiwkYvnCeyJwun3Akx9ukuBRUw==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-grExjVuKhcNOjBE9TFlxEPDYT+hmVgdmMgu3+er43GsSbVc3e7jU29zDXagx0qVWT3E1dtABqLJTsNUc/XQQlg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.25.0",
-        "@dcl/linker-dapp": "0.15.2",
+        "@dcl/linker-dapp": "0.15.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-24513367586.commit-0ed6dc3",
+        "@dcl/protocol": "1.0.0-22669986637.commit-fb11819",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -1045,21 +1048,20 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1070,9 +1072,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1210,13 +1212,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1312,9 +1314,9 @@
       }
     },
     "node_modules/@well-known-components/interfaces/node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1480,9 +1482,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1647,9 +1649,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2182,9 +2184,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2669,9 +2671,9 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.5.tgz",
-      "integrity": "sha512-+7HBrlaj3UFnNC9HqiXaIlNkwNINYkgQ2PS4h7qW/WGHC9/+OU9Xi0/tdvjjXATw3YCcpmNV7S3zDD9e10pTWg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz",
+      "integrity": "sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4191,9 +4193,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4290,9 +4292,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4404,9 +4406,9 @@
       }
     },
     "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4458,15 +4460,15 @@
       "dev": true
     },
     "@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true
     },
     "@babel/parser": {
@@ -4479,19 +4481,19 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true
     },
     "@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       }
     },
     "@dcl/catalyst-contracts": {
@@ -4501,9 +4503,9 @@
       "dev": true
     },
     "@dcl/crypto": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.6.0.tgz",
-      "integrity": "sha512-00DGe0eHq7TJlZmaa6BMy2XnhrUkkmWdGY/oVGTJdjSHFHvRk9DBgmrPeiwB5EFFlHb5hWKysJ5UwvhDU9JTtA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
       "dev": true,
       "requires": {
         "@dcl/schemas": "^25.2.0",
@@ -4526,9 +4528,9 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-ZNi2UILQvrW8drmxivtlh1x9DCDkefDGUmIDERMILH8lKAjjgYkgJ9Q+fXoJmv6J1FY0x44m45OYm8XHNG+TfA==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-qR7SoIt9ji+5Wy2SL4s2K2fTmbnTWUCaALeEAmfzKhRA/YCs6B2jm1qvuLEWkiGx5qOZNH0R0K0IiN13Gce/GA==",
       "dev": true
     },
     "@dcl/ecs-math": {
@@ -4613,9 +4615,9 @@
       },
       "dependencies": {
         "@dcl/asset-packs": {
-          "version": "2.15.2",
-          "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.15.2.tgz",
-          "integrity": "sha512-RQPcos1LvV62LuxJgw9U9+hAWPRVPrvxw8KCbhtZdpDZAdlNxPxzEgNdsEaltXWcE9V5nbeTHwxlM5V0EAQnYA==",
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.15.3.tgz",
+          "integrity": "sha512-Nmd2EyrWXqHod3v7f+Z4A8v2rhC+81knI2mRWS5RBv56krdqS0NIsj5R9SbXlskEB23+JUQbXtl6FVbVCrpMhQ==",
           "dev": true,
           "requires": {
             "@types/glob": "^8.1.0",
@@ -4624,9 +4626,9 @@
           }
         },
         "@dcl/ecs": {
-          "version": "7.23.1",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.23.1.tgz",
-          "integrity": "sha512-tRT0cw5dmybzB24bonJ8ZdSz3cb6Eu90BscNWe9R4yvoyaGue/PFx3EtUxJvN5AFI409PK+Lvr7n2uDQF3gRvQ==",
+          "version": "7.23.3",
+          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.23.3.tgz",
+          "integrity": "sha512-W0OqWDfhsI8SnUn4Hsxh5FG1LEcIyAHQlf/chP6EkMhKIhhFHOsRwYGQJCkOOEXaB6wUuyPN2wl2xTpTn8RHtQ==",
           "dev": true,
           "peer": true
         },
@@ -4637,9 +4639,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+          "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -4660,9 +4662,9 @@
           }
         },
         "lru-cache": {
-          "version": "11.3.6",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-          "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+          "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
           "dev": true
         },
         "minimatch": {
@@ -4693,15 +4695,15 @@
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-9AKi8Zpr9a1t2zuRwzwXJEWb902JR9qNWo2UIlHqLYAJIJ4+O1dF2H6NEbJsnji/oJq00TSsJwN3kavMFBVtSg==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Q088hyE1Bm8Wpxx98BRVJYeRlmZ7ty2E/oCX20Xfdo1uGlgSZ5KHLQMuNDDzi9CSwZj8oeUrzJPLq5py+mvMGQ==",
       "dev": true
     },
     "@dcl/linker-dapp": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.15.2.tgz",
-      "integrity": "sha512-aYUCfcQp0eMCZfDt+iV2wMBl3oVMsl68uMz6jSVpnfTFqEqMlCmfeh0uZTr/eVMkSvQl8JUSrsKE1aGSE//bNw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.15.0.tgz",
+      "integrity": "sha512-YwRvHzfyyHq2mj17ceRMjXEeMhPEamr+Fq1nM8/+G2OjujmofFnoQzri37zIBOJunYeEHaUP+ftoNoHgRTx73Q==",
       "dev": true
     },
     "@dcl/mini-comms": {
@@ -4738,9 +4740,9 @@
       }
     },
     "@dcl/protocol": {
-      "version": "1.0.0-24513367586.commit-0ed6dc3",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-24513367586.commit-0ed6dc3.tgz",
-      "integrity": "sha512-UOLtMPwyyhVSwzJIWMaDdN3czUQ603+ZNrU4JXSlNkbJOxV5FKHCfkUynupAUWr0zu9XtMQ5+zvGkWOoNwRF5A==",
+      "version": "1.0.0-22669986637.commit-fb11819",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-22669986637.commit-fb11819.tgz",
+      "integrity": "sha512-/N6EB6wjBbRFvVwZOW5++KIPKSQC7nxoPlIEfRYmR8Ysi1NzPCKHHftg9NiswfTRkyOPcjbaUtq9fT8jkjiTjA==",
       "dev": true,
       "requires": {
         "@dcl/ts-proto": "1.154.0",
@@ -4766,12 +4768,12 @@
       "dev": true
     },
     "@dcl/react-ecs": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-V7hXJ57GAk5Opz2GGN7h2zaU075EJJQA402rJI7c+q+w6HS30X15SJPBUGznTpLcZIBxVQGNSn0QDylf+VqXuA==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-4POOdsqhPekDfd/YiGZ7ZriPxdeD042YkpZR0gGNw1o5e+teYK2faKxwNYBN+9aGIE6DaoqXpRxi8FDiUZiEGQ==",
       "dev": true,
       "requires": {
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -4798,34 +4800,34 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-ggbInawjUjqiax23WoGFQ3P2+4nMJxM5So2DYSwfYxrZi6e6WRWq7UpKwpGBM9AASlKYxpzMkpZjRTJN+seCYw==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Z5EbZCzQEGUlhZTSo9x42gN8e02PdPE0s1JXKFp863Mzhc6uAnmmJDSe95bQ8VvfJuQcmAeD8nDCbYlo/NC2cQ==",
       "dev": true,
       "requires": {
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.22.6-25321038582.commit-63ddb3f",
-        "@dcl/react-ecs": "7.22.6-25321038582.commit-63ddb3f",
-        "@dcl/sdk-commands": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/react-ecs": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/sdk-commands": "7.21.1-22918726402.commit-ee210ee",
         "text-encoding": "0.7.0"
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.22.6-25321038582.commit-63ddb3f",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.22.6-25321038582.commit-63ddb3f.tgz",
-      "integrity": "sha512-dJRBoFJfZucut/eiBxeF1U+us1g6Uydi17jND2fXqir+9kXW9TEtb28g8mCXBiwkYvnCeyJwun3Akx9ukuBRUw==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-grExjVuKhcNOjBE9TFlxEPDYT+hmVgdmMgu3+er43GsSbVc3e7jU29zDXagx0qVWT3E1dtABqLJTsNUc/XQQlg==",
       "dev": true,
       "requires": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.22.6-25321038582.commit-63ddb3f",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.25.0",
-        "@dcl/linker-dapp": "0.15.2",
+        "@dcl/linker-dapp": "0.15.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-24513367586.commit-0ed6dc3",
+        "@dcl/protocol": "1.0.0-22669986637.commit-fb11819",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -5106,19 +5108,18 @@
       "dev": true
     },
     "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true
     },
     "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "@protobufjs/float": {
@@ -5128,9 +5129,9 @@
       "dev": true
     },
     "@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true
     },
     "@protobufjs/path": {
@@ -5242,12 +5243,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "requires": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "@types/node-fetch": {
@@ -5332,9 +5333,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.19.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-          "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+          "version": "20.19.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+          "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
           "dev": true,
           "requires": {
             "undici-types": "~6.21.0"
@@ -5460,9 +5461,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "version": "1.1.15",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+          "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5584,9 +5585,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
@@ -5960,9 +5961,9 @@
       "dev": true
     },
     "es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
@@ -6278,9 +6279,9 @@
       }
     },
     "i18next-fs-backend": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.5.tgz",
-      "integrity": "sha512-+7HBrlaj3UFnNC9HqiXaIlNkwNINYkgQ2PS4h7qW/WGHC9/+OU9Xi0/tdvjjXATw3YCcpmNV7S3zDD9e10pTWg==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz",
+      "integrity": "sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==",
       "dev": true
     },
     "ieee754": {
@@ -7370,9 +7371,9 @@
       }
     },
     "undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true
     },
     "util-deprecate": {
@@ -7442,9 +7443,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "requires": {}
     },
@@ -7523,9 +7524,9 @@
           }
         },
         "brace-expansion": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "version": "1.1.15",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+          "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
-    "@dcl/sdk": "^7.22.6-25321038582.commit-63ddb3f"
+    "@dcl/sdk": "7.21.1-22918726402.commit-ee210ee"
   },
   "engines": {
     "node": ">=16.0.0",


### PR DESCRIPTION
This repo requires the pre-release SDK/server pairing, but the dependency set had drifted out of sync:

- package.json referenced @dcl/js-runtime 7.21.1-22918726402.commit-ee210ee
- package-lock.json had newer 7.22.6... entries
- using the auth-server alias now resolves to a newer SDK build, which can reintroduce mismatched transitive versions

That mismatch caused npm ci to fail in GitHub Actions, and newer mixed versions also triggered duplicate type definition errors during build.

Changes:

- pinned @dcl/sdk to 7.21.1-22918726402.commit-ee210ee
- pinned @dcl/js-runtime to 7.21.1-22918726402.commit-ee210ee
- regenerated package-lock.json to match

Validation:

- npm run build passes
- this should unblock npm ci in CI