### PR TITLE
Fix farmer plotgroup

### DIFF
--- a/src/data/questData.ts
+++ b/src/data/questData.ts
@@ -57,6 +57,13 @@ export const QUEST_DEFINITIONS: QuestDefinition[] = [
     rewardCoins: 200, rewardXp: 100,
   },
   {
+    id: 'mayorchen_farmer', npcId: 'mayorchen', npcName: 'Mayor Chen',
+    title: 'Sell 50 crops',
+    description: "I've been reviewing the town's expansion plans. If you can sell 50 crops to the market, I'll authorize the new farming zone adjacent to your land. The town council is counting on you!",
+    type: 'sell_total', cropType: null, target: 50,
+    rewardCoins: 500, rewardXp: 200,
+  },
+  {
     id: 'mayorchen_fertilizer', npcId: 'mayorchen', npcName: 'Mayor Chen',
     title: 'Generate 5 Fertilizers',
     description: "Practice makes perfect! Add organic waste to your compost bin and collect 5 fertilizers. Your crops will thank you!",

--- a/src/game/questState.ts
+++ b/src/game/questState.ts
@@ -29,6 +29,14 @@ let onQuestAcceptedCb:  (() => void) | null = null
 let onQuestClaimedCb:   (() => void) | null = null
 let onQuestClaimableCb: (() => void) | null = null
 
+// Permanent per-quest callbacks — keyed by quest id, never cleared after firing.
+// Use for unlock side-effects (e.g. plot group unlock on specific quest completion).
+const questClaimedCallbacks = new Map<string, () => void>()
+
+export function setOnQuestClaimedById(questId: string, cb: () => void): void {
+  questClaimedCallbacks.set(questId, cb)
+}
+
 // One-shot callbacks for the progression event (plant/water/fertilize steps)
 let onNextPlantCb:         (() => void) | null = null
 let onNextWaterCb:         (() => void) | null = null
@@ -77,6 +85,7 @@ export function claimQuestReward(questId: string): void {
   const cb = onQuestClaimedCb
   onQuestClaimedCb = null
   cb?.()
+  questClaimedCallbacks.get(questId)?.()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { isServer } from '@dcl/sdk/network'
 import { getUserData } from '~system/UserIdentity'
 import { PlayerIdentityData } from '@dcl/sdk/ecs'
 import { setupUi } from './ui'
-import { setupEntities, unlockSoilsPhase1, unlockSoilsPhase2, unlockSoilsAll6, getSoilEntities, getComputerEntity, getTruckEntity, initVisitorWaterFeedback, resetSoilPlots, setCompostBinVisible } from './systems/interactionSetup'
+import { setupEntities, unlockSoilsPhase1, unlockSoilsPhase2, unlockSoilsAll6, getSoilEntities, getComputerEntity, getTruckEntity, initVisitorWaterFeedback, resetSoilPlots, setCompostBinVisible, unlockPlotGroupByName } from './systems/interactionSetup'
 import './systems/growthSystem'
 import './systems/dogSystem'
 import './systems/seedVfxSystem'
@@ -27,7 +27,7 @@ import { setupFarmServer } from './server/farmServer'
 import { initSaveService } from './services/saveService'
 import { initVisitService } from './services/visitService'
 import { initSocialService } from './services/socialService'
-import { getActiveQuestForNpc, hasOnlyBlockedQuestsForNpc } from './game/questState'
+import { getActiveQuestForNpc, hasOnlyBlockedQuestsForNpc, setOnQuestClaimedById } from './game/questState'
 import { setupInputModifierSystem } from './systems/inputModifierSystem'
 import { setupMusicSystem } from './systems/musicSystem'
 import { setupSfxSystem } from './systems/sfxSystem'
@@ -137,6 +137,15 @@ export function main() {
           !progressionEventState.active
         ) {
           triggerPigTutorial(startRegularNpcRotation)
+        }
+      })
+
+      // Unlock the farmer plot zone when Mayor Chen's sell-50 quest is claimed.
+      // Adds to unlockedPlotGroups so the save system persists and restores it.
+      setOnQuestClaimedById('mayorchen_farmer', () => {
+        unlockPlotGroupByName('PlotGroup_Farmer')
+        if (!playerState.unlockedPlotGroups.includes('PlotGroup_Farmer')) {
+          playerState.unlockedPlotGroups.push('PlotGroup_Farmer')
         }
       })
 

--- a/src/systems/tutorialSystem.ts
+++ b/src/systems/tutorialSystem.ts
@@ -6,7 +6,7 @@ import { tutorialState, TutorialActionType, tutorialCallbacks, tutorialNavState 
 import { CropType } from '../data/cropData'
 import { ALL_FERTILIZER_TYPES } from '../data/fertilizerData'
 import { MAYOR_DEF } from '../data/npcData'
-import { setOnQuestAccepted, setOnQuestClaimed, setOnQuestClaimable, resetQuestProgress } from '../game/questState'
+import { setOnQuestAccepted, setOnQuestClaimed, setOnQuestClaimable, resetQuestProgress, questProgressMap } from '../game/questState'
 import { walkNpcToPosition, requestNpcDeparture } from './npcSystem'
 import { addXp } from './levelingSystem'
 import { PlotState } from '../components/farmComponents'
@@ -374,9 +374,22 @@ export function skipTutorial() {
   playerState.activeMenu = 'none'
   setArrowTarget(null)
   tutorialCallbacks.unlockSoilsAll6()
-  requestNpcDeparture()
   addXp(3000)  // bring player to level 8 — unlocks Chicken Coop + all quest prerequisites
-  console.log('CozyFarm Tutorial: skipped via Axe (3 clicks) — level 8, 20k coins, grain x10')
+
+  // Complete all regular NPC quests and unlock rot system so the skip lands
+  // in a fully playable post-tutorial state (Mayor Chen enters normal rotation).
+  for (const id of ['rosa', 'gerald', 'marco', 'lily', 'dave', 'mayorchen']) {
+    const qp = questProgressMap.get(id)
+    if (qp) qp.status = 'completed'
+  }
+  playerState.rotSystemUnlocked    = true
+  playerState.progressionEventStep = 'complete'
+  progressionEventState.active     = false
+  progressionEventState.step       = 'complete'
+  playerState.harvested.set(CropType.Onion, 10)
+
+  requestNpcDeparture()
+  console.log('CozyFarm Tutorial: skipped via Axe (3 clicks) — level 8, 20k coins, all quests cleared')
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
in this PR:
questData.ts — New mayorchen_farmer quest ("Sell 50 crops") added to Mayor Chen's chain with npcId: 'mayorchen', reward 500 coins + 200 XP.

questState.ts — Added setOnQuestClaimedById(questId, cb): registers permanent per-quest callbacks in a Map. Fires alongside the existing one-shot callback in claimQuestReward, without interfering with the tutorial flow.

index.ts — Wires the farmer unlock: on mayorchen_farmer claim, calls unlockPlotGroupByName('PlotGroup_Farmer') and pushes to unlockedPlotGroups so the save system persists and restores it across sessions.

tutorialSystem.ts — Axe hack (3-click skip) now also marks all regular NPC quests as completed, sets rotSystemUnlocked: true, and adds 10 harvested onions to inventory. Kept permanently since it leaves the game in a fully playable post-tutorial state — Mayor Chen enters the NPC rotation immediately and the player can sell right away.

Close #37 