### PR TITLE
fix: dialogs ui

### DIFF
--- a/src/game/npcDialogState.ts
+++ b/src/game/npcDialogState.ts
@@ -8,6 +8,9 @@ export const npcDialogState = {
   npcHeadImage:        '',
   dialogLine:          '',
   mode:                'greeting' as NpcDialogMode,
+  tutorialPages:       [] as string[],
+  tutorialPage:        0,
+  tutorialFinalButtonLabel: 'Got it!',
   tutorialButtonLabel: 'Got it!',
   onClose:             null as (() => void) | null,
   onAccept:            null as (() => void) | null,  // quest_offer: called when player accepts

--- a/src/systems/animalTutorialSystem.ts
+++ b/src/systems/animalTutorialSystem.ts
@@ -25,13 +25,17 @@ export function setOnPigTutorialComplete(cb: () => void):     void { onPigTutori
 // ---------------------------------------------------------------------------
 // Dialog helper — identical pattern to progressionEventsSystem.ts
 // ---------------------------------------------------------------------------
-function showDialog(text: string, buttonLabel: string, onButton: () => void): void {
+function showDialog(text: string | string[], buttonLabel: string, onButton: () => void): void {
+  const pages = Array.isArray(text) ? text : [text]
   npcDialogState.npcName             = MAYOR_DEF.name
   npcDialogState.npcId               = MAYOR_DEF.id
   npcDialogState.npcHeadImage        = MAYOR_DEF.headImage
-  npcDialogState.dialogLine          = text
+  npcDialogState.tutorialPages       = pages
+  npcDialogState.tutorialPage        = 0
+  npcDialogState.tutorialFinalButtonLabel = buttonLabel
+  npcDialogState.dialogLine          = pages[0]
   npcDialogState.mode                = 'tutorial'
-  npcDialogState.tutorialButtonLabel = buttonLabel
+  npcDialogState.tutorialButtonLabel = pages.length > 1 ? 'Next' : buttonLabel
   npcDialogState.onClose             = onButton
   npcDialogState.onAccept            = null
   npcDialogState.onClaim             = null
@@ -55,7 +59,10 @@ function goToChickenBuyCoop(): void {
   setArrowTarget(coopEntity)
 
   showDialog(
-    "Congratulations on reaching Level 8! You've unlocked the Chicken Coop!\n\nHead over to the coop plot and buy it — chickens will provide eggs and keep your farm buzzing with life!",
+    [
+      "Congratulations on reaching Level 8! You've unlocked the Chicken Coop!...",
+      "Head over to the coop plot and buy it — chickens will provide eggs and keep your farm buzzing with life!",
+    ],
     "Let's go!",
     () => {
       playerState.activeMenu = 'none'
@@ -97,7 +104,10 @@ function goToChickenFeed(): void {
   setArrowTarget(foodEntity)
 
   showDialog(
-    "Welcome to the flock! Your chickens need grain to produce eggs — they lay 1-2 eggs every 6 hours while there's food in the bowl.\n\nFill up the food bowl to get them started!",
+    [
+      "Welcome to the flock! Your chickens need grain to produce eggs — they lay 1-2 eggs every 6 hours while there's food in the bowl...",
+      "Fill up the food bowl to get them started!",
+    ],
     "Fill the bowl!",
     () => { playerState.activeMenu = 'none' }
   )
@@ -114,7 +124,11 @@ function goToChickenCleanIntro(): void {
   setArrowTarget(null)
 
   showDialog(
-    "Great! The chickens are eating!\n\nOne more thing — the coop gets dirty every 12 hours. When you see dirt appear, click it to clean up. You'll earn organic waste for your compost bin as a bonus!\n\nEnjoy your new flock!",
+    [
+      "Great! The chickens are eating!",
+      "One more thing — the coop gets dirty every 12 hours.\n\nWhen you see dirt appear, click it to clean up.",
+      "You'll earn organic waste for your compost bin as a bonus!\n\nEnjoy your new flock!",
+    ],
     "Thanks, Mayor!",
     () => {
       playerState.activeMenu = 'none'
@@ -215,7 +229,10 @@ function goToPigBuyPen(): void {
   setArrowTarget(penEntity)
 
   showDialog(
-    "Level 12 — you've truly become a seasoned farmer! You've unlocked the Pig Pen!\n\nHead over to the pig pen plot and buy it. Pigs are a rewarding long-term investment!",
+    [
+      "Level 12 — you've truly become a seasoned farmer! You've unlocked the Pig Pen!...",
+      "Head over to the pig pen plot and buy it. Pigs are a rewarding long-term investment!",
+    ],
     "Let's go!",
     () => {
       playerState.activeMenu = 'none'
@@ -236,7 +253,10 @@ function goToPigBuyPig(): void {
   setArrowTarget(computer)
 
   showDialog(
-    "The pen is ready!\n\nNow head to the shop and buy your first pig. You can have up to 5 pigs. They start as adults — the shop sells grown pigs!",
+    [
+      "The pen is ready!...",
+      "Now head to the shop and buy your first pig. You can have up to 5 pigs. They start as adults — the shop sells grown pigs!",
+    ],
     "To the shop!",
     () => { playerState.activeMenu = 'none' }
   )
@@ -255,7 +275,10 @@ function goToPigFeed(): void {
   setArrowTarget(foodEntity)
 
   showDialog(
-    "There's your pig!\n\nPigs eat grain, veggie scraps, and harvested crops. Feeding them harvested crops also raises their feed score — a higher score means bigger pigs and more meat at harvest time. Fill the bowl!",
+    [
+      "There's your pig!\n\nPigs eat grain, veggie scraps, and harvested crops...",
+      "Feeding them harvested crops also raises their feed score — a higher score means bigger pigs and more meat at harvest time. Fill the bowl!",
+    ],
     "Fill the bowl!",
     () => { playerState.activeMenu = 'none' }
   )
@@ -272,7 +295,11 @@ function goToPigCleanIntro(): void {
   setArrowTarget(null)
 
   showDialog(
-    "Great job! The pigs are eating!\n\nKeep the pen clean — dirt appears over time and clicking it earns you organic waste for your compost bin. Adult pigs also produce manure every 8 hours automatically.",
+    [
+      "Great job! The pigs are eating!",
+      "Keep the pen clean — dirt appears over time, and clicking it earns you organic waste for your compost bin.",
+      "Adult pigs also produce manure every 8 hours automatically.",
+    ],
     "Good to know!",
     () => {
       playerState.activeMenu = 'none'
@@ -286,7 +313,11 @@ function goToPigGrowthExplained(): void {
   setArrowTarget(null)
 
   showDialog(
-    "Here's how pigs grow — shop-bought pigs start as adults. But if you breed them, piglets grow in stages:\n\n• Piglet → Adolescent in 24 hours\n• Adolescent → Adult in 72 hours\n\nFeed them well and watch them grow bigger as their feed score rises!",
+    [
+      "Here's how pigs grow — shop-bought pigs start as adults.",
+      "But if you breed them, piglets grow in stages:\n\n• Piglet → Adolescent in 24 hours\n• Adolescent → Adult in 72 hours",
+      "Feed them well and watch them grow bigger as their feed score rises!",
+    ],
     "Fascinating!",
     () => {
       playerState.activeMenu = 'none'
@@ -300,7 +331,11 @@ function goToPigBreedExplained(): void {
   setArrowTarget(null)
 
   showDialog(
-    "Once you have two adult pigs, you can breed them to get a free piglet — no coins needed! There's a cooldown between breeds, so plan ahead.\n\nOpen the animal panel and tap a pig to see breeding options.",
+    [
+      "Once you have two adult pigs, you can breed them to get a free piglet — no coins needed.",
+      "There's a cooldown between breeds, so plan ahead.",
+      "Open the animal panel and tap a pig to see breeding options.",
+    ],
     "Got it!",
     () => {
       playerState.activeMenu = 'none'

--- a/src/systems/progressionEventsSystem.ts
+++ b/src/systems/progressionEventsSystem.ts
@@ -43,13 +43,17 @@ export function fireCompostCollected(): void {
 // ---------------------------------------------------------------------------
 // Dialog helper
 // ---------------------------------------------------------------------------
-function showProgressionDialog(text: string, buttonLabel: string, onButton: () => void): void {
+function showProgressionDialog(text: string | string[], buttonLabel: string, onButton: () => void): void {
+  const pages = Array.isArray(text) ? text : [text]
   npcDialogState.npcName             = MAYOR_DEF.name
   npcDialogState.npcId               = MAYOR_DEF.id
   npcDialogState.npcHeadImage        = MAYOR_DEF.headImage
-  npcDialogState.dialogLine          = text
+  npcDialogState.tutorialPages       = pages
+  npcDialogState.tutorialPage        = 0
+  npcDialogState.tutorialFinalButtonLabel = buttonLabel
+  npcDialogState.dialogLine          = pages[0]
   npcDialogState.mode                = 'tutorial'
-  npcDialogState.tutorialButtonLabel = buttonLabel
+  npcDialogState.tutorialButtonLabel = pages.length > 1 ? 'Next' : buttonLabel
   npcDialogState.onClose             = onButton
   npcDialogState.onAccept            = null
   npcDialogState.onClaim             = null
@@ -74,7 +78,11 @@ function goToBuyCompostBin(): void {
   setArrowTarget(computer)
 
   showProgressionDialog(
-    "Wow, you've been busy! Looks like your farm has really grown since we last spoke!\n\nNow that you're levelling up, crops will start to rot if left unharvested too long. Let me help you deal with that.\n\nHead to the shop and buy a Compost Bin — it turns rotten crops into powerful fertilizers!",
+    [
+      "Wow, you've been busy! Looks like your farm has really grown since we last spoke!",
+      "Now that you're levelling up, crops will start to rot if left unharvested too long.\n\nLet me help you deal with that.",
+      "Head to the shop and buy a Compost Bin — it turns rotten crops into powerful fertilizers!",
+    ],
     "Let's go!",
     () => {
       // Arrow hides when shop opens; reappears when shop closes without buying
@@ -125,7 +133,10 @@ function goToWasteStep(): void {
   setArrowTarget(binEntity)
 
   showProgressionDialog(
-    "Great, you bought the Compost Bin! I've added 3 organic waste to your inventory.\n\nOpen the compost bin and add all 3 units — I've set it to process quickly so you can see how it works!",
+    [
+      "Great, you bought the Compost Bin! I've added 3 organic waste to your inventory...",
+      "Open the compost bin and add all 3 units — I've set it to process quickly so you can see how it works!",
+    ],
     "Got it!",
     () => {
       playerState.activeMenu = 'none'
@@ -256,7 +267,11 @@ function completeProgressionChain(): void {
   unlockFertilizerQuest()
 
   showProgressionDialog(
-    "Incredible work! Your farm is really coming together.\n\nRemember — crops will rot if left too long after harvest. Use RotShield fertilizer to prevent it, or just stay on top of your harvests!\n\nI've left you with a challenge: generate 5 more fertilizers. Come find me when you're done and I'll make it worth your while!",
+    [
+      "Incredible work! Your farm is really coming together.",
+      "Remember — crops will rot if left too long after harvest.\nUse RotShield fertilizer to prevent it, or just stay on top of your harvests.",
+      "I've left you with a challenge: generate 5 more fertilizers. Come find me when you're done and I'll make it worth your while!",
+    ],
     "Thanks, Mayor!",
     () => {
       playerState.activeMenu     = 'none'

--- a/src/systems/tutorialSystem.ts
+++ b/src/systems/tutorialSystem.ts
@@ -25,13 +25,17 @@ const HARVEST_MORE_TARGET   = 3
 // ---------------------------------------------------------------------------
 // Dialog helper — opens Mayor Chen's tutorial dialog panel
 // ---------------------------------------------------------------------------
-function showTutorialDialog(text: string, buttonLabel: string, onButton: () => void) {
+function showTutorialDialog(text: string | string[], buttonLabel: string, onButton: () => void) {
+  const pages = Array.isArray(text) ? text : [text]
   npcDialogState.npcName             = MAYOR_DEF.name
   npcDialogState.npcId               = MAYOR_DEF.id
   npcDialogState.npcHeadImage        = MAYOR_DEF.headImage
-  npcDialogState.dialogLine          = text
+  npcDialogState.tutorialPages       = pages
+  npcDialogState.tutorialPage        = 0
+  npcDialogState.tutorialFinalButtonLabel = buttonLabel
+  npcDialogState.dialogLine          = pages[0]
   npcDialogState.mode                = 'tutorial'
-  npcDialogState.tutorialButtonLabel = buttonLabel
+  npcDialogState.tutorialButtonLabel = pages.length > 1 ? 'Next' : buttonLabel
   npcDialogState.onClose             = onButton
   npcDialogState.onAccept            = null
   npcDialogState.onClaim             = null
@@ -60,7 +64,10 @@ function goToPlantFirst() {
   walkMayorToSoil(0, -1.2)
   setArrowTarget((tutorialCallbacks.getFirstSoilEntity() as import('@dcl/sdk/ecs').Entity | null))
   showTutorialDialog(
-    "Excellent! Now come here to this soil plot and try to plant your first seed.\n\nClick the soil to open the planting menu, then select Onion.",
+    [
+      "Excellent! Now come here to this soil plot and try to plant your first seed...",
+      "Click the soil to open the planting menu, then select Onion.",
+    ],
     "On my way!",
     () => {},
   )
@@ -81,7 +88,10 @@ function goToWaitGrow() {
   tutorialCallbacks.unlockSoilsPhase1()
   setArrowTarget(null)   // just waiting — no arrow needed
   showTutorialDialog(
-    "Good — now it's time to wait for the plant to grow!\n\nI'll apply a quick Fertilizer to this soil so it goes faster. I've also unlocked two more plots for you — practice planting while you wait!",
+    [
+      "Good — now it's time to wait for the plant to grow!...",
+      "I'll apply a quick Fertilizer to this soil so it goes faster. I've also unlocked two more plots for you — practice planting while you wait!",
+    ],
     "Nice, let's go!",
     () => {},
   )
@@ -114,7 +124,10 @@ function goToOpenQuests() {
   setArrowTarget(null)                      // quests button is 2D UI — no 3D arrow
   tutorialNavState.highlightQuests = true   // dim other nav buttons, bounce quests
   showTutorialDialog(
-    "On your farm you'll get a lot of nearby visitors and neighbours with requests!\n\nOpen the Quests panel using the button at the bottom of the screen to see what awaits you.",
+    [
+      "On your farm you'll get a lot of nearby visitors and neighbours with requests!...",
+      "Open the Quests panel using the button at the bottom of the screen to see what awaits you.",
+    ],
     "Show me!",
     () => {},
   )

--- a/src/ui/NpcDialogMenu.tsx
+++ b/src/ui/NpcDialogMenu.tsx
@@ -143,10 +143,27 @@ function DialogButton(props: {
 }
 
 function closeDialog() {
+  if (
+    npcDialogState.mode === 'tutorial' &&
+    npcDialogState.tutorialPages.length > 1 &&
+    npcDialogState.tutorialPage < npcDialogState.tutorialPages.length - 1
+  ) {
+    npcDialogState.tutorialPage += 1
+    npcDialogState.dialogLine = npcDialogState.tutorialPages[npcDialogState.tutorialPage]
+    npcDialogState.tutorialButtonLabel =
+      npcDialogState.tutorialPage < npcDialogState.tutorialPages.length - 1
+        ? 'Next'
+        : npcDialogState.tutorialFinalButtonLabel
+    return
+  }
+
   const cb = npcDialogState.onClose
   npcDialogState.onClose  = null
   npcDialogState.onAccept = null
   npcDialogState.onClaim  = null
+  npcDialogState.tutorialPages = []
+  npcDialogState.tutorialPage = 0
+  npcDialogState.tutorialFinalButtonLabel = 'Got it!'
   playerState.activeMenu  = 'none'
   cb?.()
 }


### PR DESCRIPTION
## Summary

This PR improves mobile readability for long NPC tutorial dialogs by adding built-in multi-page support to `NpcDialogMenu` and splitting the longest tutorial/event texts into smaller pages.

It also removes the temporary dialog debug tooling used during the review pass.

## What changed

- Added internal pagination support for tutorial-style NPC dialogs
- Updated `NpcDialogMenu` so tutorial dialogs can advance through multiple text pages before running their original close action
- Extended NPC dialog state to track tutorial pages, current page, and final button label
- Split the longest mobile-breaking dialogs into 2-page or 3-page sequences
- Applied those dialog splits in:
  - `src/systems/tutorialSystem.ts`
  - `src/systems/progressionEventsSystem.ts`
  - `src/systems/animalTutorialSystem.ts`
- Removed the temporary NPC dialog debug viewer and related debug scaffolding

## Behavior

- Tutorial dialogs now show `Next` on intermediate pages
- The original button label is restored on the final page
- The original callback only runs after the final page is confirmed

## Validation

- Ran `npm run build`
- Type checking completed without errors

Closes #122 