### PR TITLE
Fix slot asing system

### DIFF
--- a/src/game/gameState.ts
+++ b/src/game/gameState.ts
@@ -111,4 +111,6 @@ export const playerState = {
   menuInputLockDisabled: false,
   // Runtime-only: waiting-in-plaza UI state when no farm slot is available
   plazaMapMinimized: false,
+  // Runtime-only: shown when a slot frees up while the player is waiting in plaza
+  freeSlotNotification: null as { slotId: number; shownAt: number; taken: boolean } | null,
 }

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -11,7 +11,7 @@ import { WORKER_DEBUG_ENABLED } from '../shared/worker'
 // Slots are assigned when players connect and released when they disconnect.
 // Max 8 slots.
 // ---------------------------------------------------------------------------
-const MAX_FARM_SLOTS = 1 // TEST: 1 so 2 clients trigger the free-slot flow
+const MAX_FARM_SLOTS = 8
 const activeSlots  = new Map<number, string>()   // slot → wallet
 const playerSlots  = new Map<string, number>()    // wallet → slot
 

--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -11,7 +11,7 @@ import { WORKER_DEBUG_ENABLED } from '../shared/worker'
 // Slots are assigned when players connect and released when they disconnect.
 // Max 8 slots.
 // ---------------------------------------------------------------------------
-const MAX_FARM_SLOTS = 8
+const MAX_FARM_SLOTS = 1 // TEST: 1 so 2 clients trigger the free-slot flow
 const activeSlots  = new Map<number, string>()   // slot → wallet
 const playerSlots  = new Map<string, number>()    // wallet → slot
 

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -877,10 +877,16 @@ export function initSaveService(onLoaded?: () => void): void {
       playerState.farmAssignmentOverlayDurationMs = 0
       playerState.farmGameplayUiReady = false
       playSlotAssignmentOverlay = false
-      // Show "someone got it" feedback then auto-dismiss
+      // Show "someone got it" feedback then auto-dismiss.
+      // Capture reference so a fresher notification arriving during the 2s window is not wiped.
       if (playerState.freeSlotNotification && data.reason === 'slot_taken') {
-        playerState.freeSlotNotification = { ...playerState.freeSlotNotification, taken: true }
-        setTimeout(() => { playerState.freeSlotNotification = null }, 2000)
+        const takenNotif = { ...playerState.freeSlotNotification, taken: true }
+        playerState.freeSlotNotification = takenNotif
+        setTimeout(() => {
+          if (playerState.freeSlotNotification === takenNotif) {
+            playerState.freeSlotNotification = null
+          }
+        }, 2000)
       }
     }
     slotCallbacks.onSlotClaimed?.(data.success, data.reason, data.slots)

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -798,6 +798,11 @@ export function initSaveService(onLoaded?: () => void): void {
     hideFarmSlot(data.slotId)
     clearRemoteFarmSlot(data.slotId)
     console.log(`[SaveService] Farm slot ${data.slotId} hidden — player left`)
+
+    // Notify waiting players that a slot just opened
+    if (playerState.mySlotId < 0 && !playerState.farmGameplayUiReady) {
+      playerState.freeSlotNotification = { slotId: data.slotId, shownAt: Date.now(), taken: false }
+    }
   })
 
   // Another player's farm became visible — reveal their slot and render crops
@@ -863,6 +868,7 @@ export function initSaveService(onLoaded?: () => void): void {
       playerState.farmSlots = data.slots
       playerState.farmGameplayUiReady = false
       playerState.plazaMapMinimized = false
+      playerState.freeSlotNotification = null
       if (playerState.activeMenu === 'farmSelect') playerState.activeMenu = 'none'
     } else {
       playerState.farmAssignmentOverlayActive = false
@@ -871,6 +877,11 @@ export function initSaveService(onLoaded?: () => void): void {
       playerState.farmAssignmentOverlayDurationMs = 0
       playerState.farmGameplayUiReady = false
       playSlotAssignmentOverlay = false
+      // Show "someone got it" feedback then auto-dismiss
+      if (playerState.freeSlotNotification && data.reason === 'slot_taken') {
+        playerState.freeSlotNotification = { ...playerState.freeSlotNotification, taken: true }
+        setTimeout(() => { playerState.freeSlotNotification = null }, 2000)
+      }
     }
     slotCallbacks.onSlotClaimed?.(data.success, data.reason, data.slots)
   })

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -26,6 +26,7 @@ import { VisitHud }         from './ui/VisitHud'
 import { FarmSelectPanel }  from './ui/FarmSelectPanel'
 import { MAILBOX_FEATURE_ENABLED } from './game/featureFlags'
 import { FarmAssignmentOverlay } from './ui/FarmAssignmentOverlay'
+import { FreeSlotNotification }  from './ui/FreeSlotNotification'
 import { PROFILE_HUD_DEBUG } from './debug/profileHudDebug'
 
 export function setupUi() {
@@ -79,6 +80,7 @@ const MainUi = () => {
       {showOwnFarmUi && playerState.activeMenu === 'quests'    && <QuestPanel />}
       {showOwnFarmUi && playerState.activeMenu === 'farm'      && <FarmPanel />}
       <FarmAssignmentOverlay />
+      {waitingForSlot && <FreeSlotNotification />}
     </UiEntity>
   )
 }

--- a/src/ui/FreeSlotNotification.tsx
+++ b/src/ui/FreeSlotNotification.tsx
@@ -1,0 +1,102 @@
+import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
+import { playerState } from '../game/gameState'
+import { requestClaimSlot } from './FarmSelectPanel'
+import { playSound } from '../systems/sfxSystem'
+
+const TIMEOUT_S   = 20
+const BG_SRC      = 'assets/images/ui_loading/npc_dialog_background.png'
+
+const TEXT_BROWN  = { r: 0.28, g: 0.15, b: 0.04, a: 1 }
+const BTN_BG      = { r: 0.45, g: 0.26, b: 0.06, a: 1 }
+const BTN_TEXT    = { r: 0.97, g: 0.90, b: 0.68, a: 1 }
+const GOLD        = { r: 1,    g: 0.88, b: 0.5,  a: 1 }
+const RED         = { r: 0.75, g: 0.18, b: 0.08, a: 1 }
+
+export const FreeSlotNotification = () => {
+  const notif = playerState.freeSlotNotification
+  if (!notif) return null
+
+  const now       = Date.now()
+  const elapsedS  = (now - notif.shownAt) / 1000
+  const remaining = Math.max(0, Math.ceil(TIMEOUT_S - elapsedS))
+
+  // Auto-dismiss when timer runs out
+  if (remaining === 0 && !notif.taken) {
+    playerState.freeSlotNotification = null
+    return null
+  }
+
+  const taken = notif.taken
+
+  return (
+    <UiEntity
+      uiTransform={{
+        positionType: 'absolute',
+        position: { top: 0, left: 0 },
+        width: '100%',
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerFilter: 'none',
+      }}
+    >
+      <UiEntity
+        uiTransform={{
+          width: 480,
+          height: 220,
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerFilter: 'block',
+        }}
+        uiBackground={{ texture: { src: BG_SRC, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+      >
+        {/* Title */}
+        <Label
+          value={taken ? 'Someone else got it!' : 'FREE SLOT AVAILABLE!'}
+          fontSize={26}
+          color={taken ? RED : GOLD}
+          textAlign="middle-center"
+          uiTransform={{ positionType: 'absolute', position: { top: 18 } }}
+        />
+
+        {!taken && (
+          <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center' }}>
+            <Label
+              value="A farm slot just opened up!"
+              fontSize={18}
+              color={TEXT_BROWN}
+              textAlign="middle-center"
+              uiTransform={{ margin: { bottom: 16 } }}
+            />
+
+            {/* Claim button + timer */}
+            <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center' }}>
+              <UiEntity
+                uiTransform={{
+                  width: 180, height: 52,
+                  alignItems: 'center', justifyContent: 'center',
+                  borderRadius: 10, margin: { right: 16 },
+                }}
+                uiBackground={{ color: BTN_BG }}
+                onMouseDown={() => {
+                  playSound('buttonclick')
+                  requestClaimSlot(notif.slotId)
+                }}
+              >
+                <Label value="CLAIM SLOT" fontSize={20} color={BTN_TEXT} textAlign="middle-center" />
+              </UiEntity>
+
+              <Label
+                value={`${remaining}s`}
+                fontSize={22}
+                color={remaining <= 5 ? RED : TEXT_BROWN}
+                textAlign="middle-center"
+              />
+            </UiEntity>
+          </UiEntity>
+        )}
+      </UiEntity>
+    </UiEntity>
+  )
+}

--- a/src/ui/FreeSlotNotification.tsx
+++ b/src/ui/FreeSlotNotification.tsx
@@ -1,4 +1,5 @@
 import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
+import { isMobile } from '@dcl/sdk/platform'
 import { playerState } from '../game/gameState'
 import { requestClaimSlot } from './FarmSelectPanel'
 import { playSound } from '../systems/sfxSystem'
@@ -13,8 +14,11 @@ const GOLD        = { r: 1,    g: 0.88, b: 0.5,  a: 1 }
 const RED         = { r: 0.75, g: 0.18, b: 0.08, a: 1 }
 
 export const FreeSlotNotification = () => {
-  const notif = playerState.freeSlotNotification
+  const notif  = playerState.freeSlotNotification
   if (!notif) return null
+
+  const mobile = isMobile()
+  const d      = (v: number) => Math.round(v * (mobile ? 1.5 : 1))
 
   const now       = Date.now()
   const elapsedS  = (now - notif.shownAt) / 1000
@@ -42,8 +46,8 @@ export const FreeSlotNotification = () => {
     >
       <UiEntity
         uiTransform={{
-          width: 480,
-          height: 220,
+          width: d(480),
+          height: d(220),
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
@@ -54,10 +58,10 @@ export const FreeSlotNotification = () => {
         {/* Title — always visible */}
         <Label
           value="FREE SLOT AVAILABLE!"
-          fontSize={26}
+          fontSize={d(26)}
           color={GOLD}
           textAlign="middle-center"
-          uiTransform={{ positionType: 'absolute', position: { top: 18 } }}
+          uiTransform={{ positionType: 'absolute', position: { top: d(18) } }}
         />
 
         {/* Body area */}
@@ -65,7 +69,7 @@ export const FreeSlotNotification = () => {
           <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center' }}>
             <Label
               value="Someone else got it!"
-              fontSize={18}
+              fontSize={d(18)}
               color={RED}
               textAlign="middle-center"
             />
@@ -74,19 +78,19 @@ export const FreeSlotNotification = () => {
           <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center' }}>
             <Label
               value="A farm slot just opened up!"
-              fontSize={18}
+              fontSize={d(18)}
               color={TEXT_BROWN}
               textAlign="middle-center"
-              uiTransform={{ margin: { bottom: 16 } }}
+              uiTransform={{ margin: { bottom: d(16) } }}
             />
 
             {/* Claim button + timer */}
             <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center' }}>
               <UiEntity
                 uiTransform={{
-                  width: 180, height: 52,
+                  width: d(180), height: d(52),
                   alignItems: 'center', justifyContent: 'center',
-                  borderRadius: 10, margin: { right: 16 },
+                  borderRadius: d(10), margin: { right: d(16) },
                 }}
                 uiBackground={{ color: BTN_BG }}
                 onMouseDown={() => {
@@ -94,12 +98,12 @@ export const FreeSlotNotification = () => {
                   requestClaimSlot(notif.slotId)
                 }}
               >
-                <Label value="CLAIM SLOT" fontSize={20} color={BTN_TEXT} textAlign="middle-center" />
+                <Label value="CLAIM SLOT" fontSize={d(20)} color={BTN_TEXT} textAlign="middle-center" />
               </UiEntity>
 
               <Label
                 value={`${remaining}s`}
-                fontSize={22}
+                fontSize={d(22)}
                 color={remaining <= 5 ? RED : TEXT_BROWN}
                 textAlign="middle-center"
               />

--- a/src/ui/FreeSlotNotification.tsx
+++ b/src/ui/FreeSlotNotification.tsx
@@ -51,16 +51,26 @@ export const FreeSlotNotification = () => {
         }}
         uiBackground={{ texture: { src: BG_SRC, wrapMode: 'clamp' }, textureMode: 'stretch' }}
       >
-        {/* Title */}
+        {/* Title — always visible */}
         <Label
-          value={taken ? 'Someone else got it!' : 'FREE SLOT AVAILABLE!'}
+          value="FREE SLOT AVAILABLE!"
           fontSize={26}
-          color={taken ? RED : GOLD}
+          color={GOLD}
           textAlign="middle-center"
           uiTransform={{ positionType: 'absolute', position: { top: 18 } }}
         />
 
-        {!taken && (
+        {/* Body area */}
+        {taken ? (
+          <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center' }}>
+            <Label
+              value="Someone else got it!"
+              fontSize={18}
+              color={RED}
+              textAlign="middle-center"
+            />
+          </UiEntity>
+        ) : (
           <UiEntity uiTransform={{ flexDirection: 'column', alignItems: 'center' }}>
             <Label
               value="A farm slot just opened up!"


### PR DESCRIPTION
in this PR:
Free Slot Notification for Waiting Players

When all 8 farm slots are occupied, players waiting in the plaza now receive a real-time notification when a slot opens up.

When a slot is released, all waiting players (those with mySlotId < 0) see a centered "FREE SLOT AVAILABLE!" banner with a 20-second countdown and a "CLAIM SLOT" button
First player to press the button wins the slot — the server validates atomically via the existing claimSpecificSlot() race-condition guard
If the slot was already taken by someone else, the banner body updates to "Someone else got it!" and auto-dismisses after 2 seconds
If nobody claims within 20 seconds, the banner dismisses itself
New freeSlotNotification field added to playerState to drive the UI
New FreeSlotNotification.tsx component using the parchment background style consistent with the rest of the UI

Close #91 