### PR TITLE
fix: farms overlaping

### DIFF
--- a/src/server/farmServer.ts
+++ b/src/server/farmServer.ts
@@ -115,6 +115,13 @@ function getDisplayName(address: string): string {
 
 async function loadAndSend(address: string, requestId: string): Promise<void> {
   const normalized = address.toLowerCase()
+
+  // Assign slot BEFORE any await so concurrent loadAndSend calls can never
+  // both see the same slot as free. assignSlot is synchronous; nothing can
+  // interleave between it and the broadcast below.
+  const slotId = assignSlot(normalized)
+  void room.send('farmSlotsLoaded', { requester: normalized, slots: getActiveSlotsPayload() })
+
   const farm = await store.load(normalized)
 
   // Update display name on every connect so it stays current
@@ -129,23 +136,19 @@ async function loadAndSend(address: string, requestId: string): Promise<void> {
   // Register in directory on every connect so returning players appear immediately
   void updatePlayerRegistry(normalized, farm.level, getDisplayName(normalized))
 
-  // Assign in-memory session slot
-  const slotId = assignSlot(normalized)
-  const slots  = getActiveSlotsPayload()
-  void room.send('farmSlotsLoaded', { requester: normalized, slots })
-
-  for (const [activeSlotId, activeWallet] of activeSlots.entries()) {
-    const visualPayload = buildFarmSlotVisualPayload(activeSlotId, activeWallet)
-    if (!visualPayload) continue
-    void room.send('farmSlotVisualUpdated', visualPayload, { to: [normalized] })
-  }
-
   if (slotId !== null) {
     console.log(`[FarmServer] Slot ${slotId} assigned to ${normalized}`)
     const visualPayload = buildFarmSlotVisualPayload(slotId, normalized)
     if (visualPayload) void room.send('farmSlotVisualUpdated', visualPayload)
   } else {
     console.log(`[FarmServer] No free slots for ${normalized} — spawning in plaza`)
+  }
+
+  for (const [activeSlotId, activeWallet] of activeSlots.entries()) {
+    if (activeWallet === normalized) continue
+    const visualPayload = buildFarmSlotVisualPayload(activeSlotId, activeWallet)
+    if (!visualPayload) continue
+    void room.send('farmSlotVisualUpdated', visualPayload, { to: [normalized] })
   }
 }
 
@@ -186,6 +189,11 @@ async function cleanupDisconnectedPlayers(): Promise<void> {
 
 async function ensurePlayerSessionLoaded(address: string): Promise<number | null> {
   const normalized = address.toLowerCase()
+
+  // Assign slot BEFORE any await — same race-condition fix as loadAndSend.
+  const slotId = assignSlot(normalized)
+  void room.send('farmSlotsLoaded', { requester: normalized, slots: getActiveSlotsPayload() })
+
   if (!loadedAddresses.has(normalized)) {
     const farm = await store.load(normalized)
     farm.wallet = normalized
@@ -193,10 +201,8 @@ async function ensurePlayerSessionLoaded(address: string): Promise<number | null
     void updatePlayerRegistry(normalized, farm.level, getDisplayName(normalized), farm.beautyScore)
   }
 
-  const slotId = assignSlot(normalized)
-  void room.send('farmSlotsLoaded', { requester: normalized, slots: getActiveSlotsPayload() })
-
   for (const [activeSlotId, activeWallet] of activeSlots.entries()) {
+    if (activeWallet === normalized) continue
     const visualPayload = buildFarmSlotVisualPayload(activeSlotId, activeWallet)
     if (!visualPayload) continue
     void room.send('farmSlotVisualUpdated', visualPayload, { to: [normalized] })
@@ -575,10 +581,11 @@ export async function onPlayerDisconnect(address: string): Promise<void> {
   loadedAddresses.delete(normalized)
   console.log(`[FarmServer] Saved and evicted ${normalized} on disconnect`)
 
-  // Release farm slot and notify all clients to hide this farm
+  // Release farm slot and broadcast updated map to all clients
   const slotId = releaseSlot(normalized)
   if (slotId !== null) {
     console.log(`[FarmServer] Slot ${slotId} released — broadcasting farmSlotReleased`)
     void room.send('farmSlotReleased', { slotId })
+    void room.send('farmSlotsLoaded', { requester: normalized, slots: getActiveSlotsPayload() })
   }
 }


### PR DESCRIPTION
## Summary

- **Fix slot assignment race condition**: `assignSlot` was called *after* `await store.load()` in both `loadAndSend` and `ensurePlayerSessionLoaded`. If two players connected simultaneously, both handlers would suspend at the `await`, and when both resumed they would each see slot 0 as free — resulting in two players claiming the same slot. Moving `assignSlot` and the `farmSlotsLoaded` broadcast to *before* the first `await` makes the assignment atomic: nothing can interleave between two synchronous lines in a single-threaded JS runtime.

- **Consistent slot map broadcast on disconnect**: `onPlayerDisconnect` only sent `farmSlotReleased` but not `farmSlotsLoaded`, while `cleanupDisconnectedPlayers` sent both. This inconsistency could leave clients with a stale map after an explicit disconnect. Both paths now broadcast the full authoritative slot list so every client always has the same view of who owns which farm.

- **Server is the single source of truth**: slot assignment and the slot map are now fully server-driven. The client never derives its own slot — it waits for the server's `farmSlotsLoaded` broadcast and applies it as-is.

## Test plan

- [ ] Two players connect at the exact same time — each lands on a different slot, no collision
- [ ] Player disconnects — all other clients' maps update immediately to show the slot as empty
- [ ] Server restart with active clients — reconnecting players are re-assigned without slot collisions
- [ ] Player at slot 0 leaves and a new player joins — new player correctly gets slot 0, not a collision

Closes #131 