### PR TITLE
fix: freezing avatar

### DIFF
--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -48,6 +48,7 @@ const SLOT_ASSIGNMENT_OVERLAY_INTRO_MS = 2_000
 const SLOT_ASSIGNMENT_OVERLAY_PROGRESS_MS = 4_200
 const SLOT_ASSIGNMENT_OVERLAY_TOTAL_MS = SLOT_ASSIGNMENT_OVERLAY_INTRO_MS + SLOT_ASSIGNMENT_OVERLAY_PROGRESS_MS
 const INITIAL_LOAD_RETRY_DELAY_S = 2
+const OVERLAY_HARD_TIMEOUT_MS = 15_000  // force-unfreeze if server never responds
 let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
 let farmLoaded = false
 
@@ -610,7 +611,7 @@ export function teleportToSlot(slotId: number): void {
 export function initSaveService(onLoaded?: () => void): void {
   playerState.farmAssignmentOverlayActive = true
   playerState.farmAssignmentOverlaySlotId = -1
-  playerState.farmAssignmentOverlayStartedAt = 0
+  playerState.farmAssignmentOverlayStartedAt = Date.now()
   playerState.farmAssignmentOverlayDurationMs = SLOT_ASSIGNMENT_OVERLAY_TOTAL_MS
   // Track server connection state — onReady fires true on connect, false on disconnect
   room.onReady((isReady) => {
@@ -651,6 +652,20 @@ export function initSaveService(onLoaded?: () => void): void {
         teleportToSlot(pendingTeleportSlotId)
         pendingTeleportSlotId = null
       }
+      return
+    }
+
+    // Hard timeout: if the overlay is still active and no teleport is pending,
+    // the server never completed the handshake — unfreeze to plaza so the
+    // player is not stuck indefinitely.
+    if (
+      playerState.farmAssignmentOverlayActive &&
+      Date.now() - playerState.farmAssignmentOverlayStartedAt > OVERLAY_HARD_TIMEOUT_MS
+    ) {
+      console.error('[SaveService] Overlay hard timeout — forcing plaza teleport and retrying load')
+      teleportToSlot(-1)
+      requestPlayerLoad()
+      return
     }
 
     // Recovery: slot was assigned but payload never arrived — re-request from server


### PR DESCRIPTION
## fix: unfreeze avatar when farm loading overlay times out

### Problem

On connect, `farmAssignmentOverlayActive` is set to `true` and locks all avatar inputs via `InputModifier`. The overlay only clears once the server responds with a slot assignment and the client calls `teleportToSlot()`. If the server handshake stalls or the `farmSlotsLoaded` message never arrives, the player is permanently frozen — no movement, no interaction.

### Fix

- Record `farmAssignmentOverlayStartedAt = Date.now()` at boot (was `0`, making the elapsed time calculation useless)
- Add a 15-second hard timeout in `saveServiceSlotRecoverySystem`: if the overlay is still active and no teleport is pending after `OVERLAY_HARD_TIMEOUT_MS`, force-teleport the player to the plaza (`slotId = -1`) and retry the server load request — clearing the freeze regardless of server state

### Behavior

| Scenario | Before | After |
|---|---|---|
| Normal connect | Overlay clears ~6s | Unchanged |
| Server stalls / no response | Player frozen forever | Auto-unfreezes after 15s, retries load |
| Server responds late (after timeout) | — | Second `farmSlotsLoaded` re-assigns slot normally |


Closes #133 