### PR TITLE
fix: remove input modifiers and teleports

### DIFF
--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -659,15 +659,14 @@ export function initSaveService(onLoaded?: () => void): void {
       return
     }
 
-    // Hard timeout: if the overlay is still active and no teleport is pending,
-    // the server never completed the handshake — unfreeze to plaza so the
-    // player is not stuck indefinitely.
+    // Hard timeout: server never responded — keep the overlay up and retry.
+    // Player already spawns in plaza by default, so no teleport needed.
     if (
       playerState.farmAssignmentOverlayActive &&
       Date.now() - playerState.farmAssignmentOverlayStartedAt > OVERLAY_HARD_TIMEOUT_MS
     ) {
-      console.error('[SaveService] Overlay hard timeout — forcing plaza teleport and retrying load')
-      teleportToSlot(-1)
+      console.error('[SaveService] Overlay hard timeout — retrying load')
+      playerState.farmAssignmentOverlayStartedAt = Date.now()
       requestPlayerLoad()
       return
     }
@@ -842,7 +841,11 @@ export function initSaveService(onLoaded?: () => void): void {
     const mine = normalizedWallet ? data.slots.find((s) => normalizeAddress(s.wallet) === normalizedWallet) : undefined
     const nextMySlotId = mine ? mine.slotId : playerState.mySlotId
 
-    if (!mine && !playerState.viewingFarm) {
+    // Only dismiss the overlay once the farm is fully initialized. Before that,
+    // any farmSlotsLoaded (from another player's connect/disconnect) could arrive
+    // with the current player absent from the slot list — a false-negative that
+    // would prematurely close the loading screen and expose the default spawn position.
+    if (!mine && !playerState.viewingFarm && localFarmInitialized) {
       playerState.farmAssignmentOverlayActive = false
       playerState.farmGameplayUiReady = false
     }

--- a/src/systems/inputModifierSystem.ts
+++ b/src/systems/inputModifierSystem.ts
@@ -1,34 +1,11 @@
 import { engine, InputModifier } from '@dcl/sdk/ecs'
-import { playerState } from '../game/gameState'
-
-/**
- * Suppresses the mobile joystick while any menu is open.
- *
- * InputModifier must be applied to engine.PlayerEntity to affect the player.
- * disableAll: true tells the renderer to suppress ALL movement input,
- * which prevents the joystick from appearing on mobile entirely.
- */
-
-let menuWasOpen = false
 
 export function setupInputModifierSystem() {
-  engine.addSystem(() => {
-    const menuOpen =
-      !playerState.menuInputLockDisabled &&
-      (playerState.activeMenu !== 'none' || playerState.farmAssignmentOverlayActive)
-
-    if (menuOpen === menuWasOpen) return
-    menuWasOpen = menuOpen
-
-    if (menuOpen) {
-      InputModifier.createOrReplace(engine.PlayerEntity, {
-        mode: {
-          $case: 'standard',
-          standard: { disableAll: true },
-        },
-      })
-    } else {
-      InputModifier.deleteFrom(engine.PlayerEntity)
-    }
-  })
+  // Remove any InputModifier that may have been left from a previous load.
+  // Named so it can self-remove after running once.
+  function clearInputModifier() {
+    InputModifier.deleteFrom(engine.PlayerEntity)
+    engine.removeSystem(clearInputModifier)
+  }
+  engine.addSystem(clearInputModifier)
 }


### PR DESCRIPTION
## Summary

- **Remove avatar movement lock when UI is open**: The `InputModifier.disableAll` system that suppressed the mobile joystick and keyboard movement whenever a menu was open has been removed. The per-panel `pointerFilter: 'block'` full-screen overlays already prevent accidental 3D world clicks, so the movement lock was redundant and caused jarring UX on mobile.

- **Fix premature loading screen dismissal (mobile blink)**: `farmSlotsLoaded` events fired by other players connecting/disconnecting could arrive during the local player's initial load — before their slot was assigned — causing the loading overlay to close early and briefly expose the default spawn. Guarded with `localFarmInitialized` so the overlay only dismisses after the farm is fully ready.

- **Remove teleport on hard timeout**: The 15 s hard timeout previously called `teleportToSlot(-1)` (plaza coords) when the server never responded. Since DCL already spawns the player in plaza by default, this teleport was unnecessary and confusing. Now the overlay stays up and the load is retried silently every 15 s until the server connects.

## Test plan

- [ ] Open any menu (shop, inventory, plant, etc.) — avatar should be able to move freely on desktop (WASD) and mobile joystick should remain visible
- [ ] Enter the scene without a server connection — loading overlay should stay up indefinitely; no teleport behind farm 1
- [ ] Have a second player connect/disconnect while the first player is still in the loading screen — overlay should not close prematurely
- [ ] Normal flow (server connects) — farm loads correctly and overlay dismisses as expected

Closes #145 
Closes #146 
