### PR TITLE
ft: mobile ui improvements

### DIFF
--- a/scripts/ensure-preview-sdk-shims.mjs
+++ b/scripts/ensure-preview-sdk-shims.mjs
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const rootDir = process.cwd()
+const sdkDir = path.join(rootDir, 'node_modules', '@dcl', 'sdk')
+const ecsDir = path.join(rootDir, 'node_modules', '@dcl', 'ecs')
+
+if (!fs.existsSync(sdkDir)) {
+  process.exit(0)
+}
+
+const jsTarget = path.join(sdkDir, 'text-codec.js')
+const dtsTarget = path.join(sdkDir, 'text-codec.d.ts')
+const jsContents = "export { polyfillTextEncoder } from './ethereum-provider/text-encoder'\n"
+const dtsContents = "export { polyfillTextEncoder } from './ethereum-provider/text-encoder'\n"
+
+if (!fs.existsSync(jsTarget)) {
+  fs.writeFileSync(jsTarget, jsContents, 'utf8')
+}
+
+if (!fs.existsSync(dtsTarget)) {
+  fs.writeFileSync(dtsTarget, dtsContents, 'utf8')
+}
+
+if (fs.existsSync(ecsDir)) {
+  const ecsIndexJs = path.join(ecsDir, 'dist', 'index.js')
+  const ecsIndexDts = path.join(ecsDir, 'dist', 'index.d.ts')
+  const jsShim = `
+const __compositeProviderByEngine = new WeakMap();
+let __defaultCompositeProvider = null;
+export function setCompositeProvider(engineOrProvider, maybeProvider) {
+  if (maybeProvider === undefined) {
+    __defaultCompositeProvider = engineOrProvider;
+    return;
+  }
+  __defaultCompositeProvider = maybeProvider;
+  __compositeProviderByEngine.set(engineOrProvider, maybeProvider);
+}
+export function getCompositeProvider(engine) {
+  return engine ? __compositeProviderByEngine.get(engine) ?? __defaultCompositeProvider : __defaultCompositeProvider;
+}
+`
+  const dtsShim = `
+export declare function setCompositeProvider(engineOrProvider: unknown, maybeProvider?: unknown): void;
+export declare function getCompositeProvider(engine?: unknown): unknown;
+`
+
+  if (fs.existsSync(ecsIndexJs)) {
+    const source = fs.readFileSync(ecsIndexJs, 'utf8')
+    if (!source.includes('export function getCompositeProvider(')) {
+      fs.writeFileSync(ecsIndexJs, source + jsShim, 'utf8')
+    }
+  }
+
+  if (fs.existsSync(ecsIndexDts)) {
+    const source = fs.readFileSync(ecsIndexDts, 'utf8')
+    if (!source.includes('export declare function getCompositeProvider(')) {
+      fs.writeFileSync(ecsIndexDts, source + dtsShim, 'utf8')
+    }
+  }
+}

--- a/src/example.stories.tsx
+++ b/src/example.stories.tsx
@@ -1,0 +1,22 @@
+// Component stories for `sdk-commands ui-preview`. NOT part of the deployed scene.
+// Every exported function is a story rendered on its own, centered on the canvas.
+import { Color4 } from '@dcl/sdk/math'
+import ReactEcs, { Label, UiEntity } from '@dcl/sdk/react-ecs'
+
+export default { title: 'Examples/Badge' }
+
+const Badge = (props: { text: string; color: Color4 }) => (
+  <UiEntity
+    uiTransform={{
+      padding: { top: 6, bottom: 6, left: 16, right: 16 },
+      borderRadius: 14,
+      alignItems: 'center',
+    }}
+    uiBackground={{ color: props.color }}
+  >
+    <Label value={props.text} fontSize={14} color={Color4.White()} />
+  </UiEntity>
+)
+
+export const Success = () => <Badge text="success" color={Color4.create(0.18, 0.65, 0.35, 1)} />
+export const Warning = () => <Badge text="warning" color={Color4.create(0.85, 0.6, 0.1, 1)} />

--- a/src/game/actions.ts
+++ b/src/game/actions.ts
@@ -190,8 +190,7 @@ export function setSoilTimerText(soilEntity: Entity, text: string) {
       text,
       fontSize: 3,
       textColor: { r: 1, g: 1, b: 1, a: 1 },
-      outlineWidth: 0.15,
-      outlineColor: { r: 0, g: 0, b: 0 },
+      outlineWidth: 0,
     })
     timerTextEntities.set(soilEntity, child)
   } else {

--- a/src/systems/xpFloatSystem.ts
+++ b/src/systems/xpFloatSystem.ts
@@ -50,11 +50,9 @@ export function spawnXpFloat(amount: number): void {
   Billboard.create(entity, { billboardMode: BillboardMode.BM_Y })
 
   TextShape.create(entity, {
-    text:         `+${amount} XP`,
-    fontSize:     4,
-    textColor:    Color4.create(0.25, 1, 0.35, 1),
-    outlineWidth: 0.18,
-    outlineColor: Color4.create(0, 0.2, 0, 1),
+    text:      `+${amount} XP`,
+    fontSize:  4,
+    textColor: Color4.create(0.25, 1, 0.35, 1),
   })
 
   // Float upward 2.5 units over 2 seconds

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -52,7 +52,7 @@ const MainUi = () => {
     >
       {showOwnFarmUi && <TopHud />}
       {showVisitHud && <VisitHud />}
-      {showOwnFarmUi && !['farmSelect','npcDialog','shop','inventory','farm','quests'].includes(playerState.activeMenu) && <BottomNav />}
+      {showOwnFarmUi && !['farmSelect','npcDialog','shop','inventory','farm','quests','plant'].includes(playerState.activeMenu) && <BottomNav />}
 
       {showOwnFarmUi && playerState.activeMenu === 'plant'     && <PlantMenu />}
       {showOwnFarmUi && playerState.activeMenu === 'fertilize' && <FertilizeMenu />}

--- a/src/ui/ChickenCoopPanel.tsx
+++ b/src/ui/ChickenCoopPanel.tsx
@@ -89,14 +89,6 @@ const CoopCard = ({
       }}
       uiBackground={{ color: CARD_FILL }}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: CARD_W, height: CARD_H }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
       {children}
     </UiEntity>
   )

--- a/src/ui/FarmPanel.tsx
+++ b/src/ui/FarmPanel.tsx
@@ -6,6 +6,7 @@ import { CROP_HARVEST_IMAGES, SOIL_ICON, ORGANIC_WASTE_ICON } from '../data/imag
 import { getSoilEntities } from '../systems/interactionSetup'
 import { getWateringStatus } from '../game/actions'
 import { playerState } from '../game/gameState'
+import { tutorialState } from '../game/tutorialState'
 import { C } from './PanelShell'
 import { getRotTimeMs } from '../game/rotUtils'
 import { ALL_FERTILIZER_TYPES, FERTILIZER_DATA, FertilizerType, randomFertilizer } from '../data/fertilizerData'
@@ -40,7 +41,7 @@ const CARD_TEXT       = { r: 0.22, g: 0.12, b: 0.04, a: 1 }
 const CARD_TEXT_MUTE  = { r: 0.45, g: 0.28, b: 0.10, a: 1 }
 const FRAME_THICKNESS = 4
 
-// ─── Card & bar dimensions ────────────────────────────────────────────────────
+// ─── Card & bar dimensions — desktop ─────────────────────────────────────────
 const CARD_W      = ss(215)
 const CARD_H      = ss(258)
 const CARD_MARGIN = ss(12)
@@ -50,13 +51,30 @@ const CARD_PAD_H  = ss(10)
 const BAR_H       = 12
 const BAR_RADIUS  = 6
 
+// ─── Card & bar dimensions — mobile ──────────────────────────────────────────
+const MOB_CARD_W      = ss(305)
+const MOB_CARD_H      = ss(400)
+const MOB_CARD_MARGIN = ss(25)
+const MOB_CARD_ICON   = ss(150)
+const MOB_CARD_PAD_V  = ss(26)
+const MOB_CARD_PAD_H  = ss(18)
+const MOB_BAR_H       = 16
+const MOB_BAR_RADIUS  = 8
+
 // ─── Tab bar ──────────────────────────────────────────────────────────────────
 const TAB_H   = ss(44)
 const TAB_W   = ss(175)
 const TAB_GAP = ss(10)
 
-const PLOTS_PER_PAGE  = 8
+const MOB_TAB_H   = ss(60)
+const MOB_TAB_W   = ss(240)
+const MOB_TAB_GAP = ss(12)
+
+const PLOTS_PER_PAGE     = 8
+const MOB_PLOTS_PER_PAGE = 3
 const COMPOST_CYCLE_MS = 300_000
+// Explicit height for the mobile plot area so absolute children can anchor from the bottom
+const MOB_PLOT_AREA_H  = CONTENT_H - MOB_TAB_H - ss(12)
 
 const farmTab  = { value: 'home' as 'home' | 'expansion' | 'compost' }
 const farmPage = { home: 0, expansion: 0 }
@@ -86,38 +104,37 @@ function formatTime(ms: number): string {
 // ─── FarmCard ─────────────────────────────────────────────────────────────────
 const FarmCard = ({
   borderColor = CARD_BORDER,
-  height = CARD_H,
+  fillColor = CARD_FILL,
+  height,
   children,
 }: {
   key?: string | number
   borderColor?: CardColor
+  fillColor?: CardColor
   height?: number
   children?: ReactEcs.JSX.ReactNode
 }) => {
   const mobile = isMobile()
+  const cW = mobile ? MOB_CARD_W      : CARD_W
+  const cH = height ?? (mobile ? MOB_CARD_H : CARD_H)
+  const cM = mobile ? MOB_CARD_MARGIN : CARD_MARGIN
+  const pV = mobile ? MOB_CARD_PAD_V  : CARD_PAD_V
+  const pH = mobile ? MOB_CARD_PAD_H  : CARD_PAD_H
   return (
     <UiEntity
       uiTransform={{
         flexDirection: 'column',
         alignItems: 'center',
-        width: CARD_W,
-        height,
-        margin: { right: CARD_MARGIN, bottom: CARD_MARGIN },
-        padding: { top: CARD_PAD_V, bottom: CARD_PAD_V, left: CARD_PAD_H, right: CARD_PAD_H },
-        borderWidth: 3,
+        width: cW,
+        height: cH,
+        margin: { right: cM, bottom: cM },
+        padding: { top: pV, bottom: pV, left: pH, right: pH },
+        borderWidth: mobile ? 0 : 3,
         borderColor,
-        borderRadius: 12,
+        borderRadius: mobile ? 0 : 12,
       }}
-      uiBackground={{ color: CARD_FILL }}
+      uiBackground={{ color: fillColor }}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: CARD_W, height }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height }} uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
       {children}
     </UiEntity>
   )
@@ -198,27 +215,40 @@ const TabBar = ({
   tab: 'home' | 'expansion' | 'compost'
   homeHasReady: boolean
   expansionHasReady: boolean
-}) => (
-  <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', width: '100%', margin: { bottom: ss(12) }, flexShrink: 0 }}>
-    {(['home', 'expansion', 'compost'] as const).map((t) => {
-      const active = tab === t
-      const label  = t === 'home' ? 'My Farm' : t === 'expansion' ? 'Expansion' : 'Compost Bin'
-      const hasReady = (t === 'home' && homeHasReady) || (t === 'expansion' && expansionHasReady)
-      return (
-        <UiEntity key={t} uiTransform={{ margin: { right: TAB_GAP } }}>
-          <UiEntity
-            uiTransform={{ width: TAB_W, height: TAB_H, alignItems: 'center', justifyContent: 'center', borderRadius: 10 }}
-            uiBackground={{ color: active ? { r: 0.45, g: 0.26, b: 0.06, a: 0.9 } : { r: 0.58, g: 0.38, b: 0.12, a: 0.72 } }}
-            onMouseDown={() => { playSound('buttonclick'); farmTab.value = t }}
-          >
-            <Label value={label} fontSize={ss(20)} color={active ? { r: 0.97, g: 0.90, b: 0.68, a: 1 } : { r: 0.97, g: 0.90, b: 0.68, a: 0.65 }} textAlign="middle-center" />
+}) => {
+  const mob = isMobile()
+  const tH  = mob ? MOB_TAB_H   : TAB_H
+  const tW  = mob ? MOB_TAB_W   : TAB_W
+  const tG  = mob ? MOB_TAB_GAP : TAB_GAP
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', width: '100%', margin: { bottom: ss(12) }, flexShrink: 0 }}>
+      {(['home', 'expansion', 'compost'] as const).map((t) => {
+        const active   = tab === t
+        const label    = t === 'home' ? 'My Farm' : t === 'expansion' ? 'Expansion' : 'Compost Bin'
+        const hasReady = (t === 'home' && homeHasReady) || (t === 'expansion' && expansionHasReady)
+        return (
+          <UiEntity key={t} uiTransform={{ margin: { right: tG } }}>
+            <UiEntity
+              uiTransform={{ width: tW, height: tH, alignItems: 'center', justifyContent: 'center', borderRadius: 10 }}
+              uiBackground={{ color: active ? { r: 0.45, g: 0.26, b: 0.06, a: 0.9 } : { r: 0.58, g: 0.38, b: 0.12, a: 0.72 } }}
+              onMouseDown={() => { playSound('buttonclick'); farmTab.value = t }}
+            >
+              <Label
+                value={label}
+                fontSize={mob ? ss(28) : ss(20)}
+                color={active
+                  ? (mob ? { r: 1, g: 1, b: 1, a: 1 } : { r: 0.97, g: 0.90, b: 0.68, a: 1 })
+                  : (mob ? { r: 1, g: 1, b: 1, a: 0.65 } : { r: 0.97, g: 0.90, b: 0.68, a: 0.65 })}
+                textAlign="middle-center"
+              />
+            </UiEntity>
+            {hasReady && <BadgeDot />}
           </UiEntity>
-          {hasReady && <BadgeDot />}
-        </UiEntity>
-      )
-    })}
-  </UiEntity>
-)
+        )
+      })}
+    </UiEntity>
+  )
+}
 
 // ─── PlotTile ─────────────────────────────────────────────────────────────────
 type TileProps = { key?: string | number; entity: ReturnType<typeof getSoilEntities>[number]; idx: number; now: number }
@@ -275,20 +305,26 @@ const PlotTile = ({ entity, idx, now }: TileProps) => {
       midColor    = C.blue
     } else {
       const elapsed = now - plot.plantedAt
-      barPct        = Math.min(100, Math.floor((elapsed / def.growTimeMs) * 100))
-      const ws      = getWateringStatus(plot, now)
+      // Mirror growthSystem.ts: tutorial onion grows in 30s; GrowthBoost cuts time by 25%
+      let effectiveGrowTimeMs = (tutorialState.active && ct === CropType.Onion) ? 30_000 : def.growTimeMs
+      if (plot.fertilizerType === FertilizerType.GrowthBoost) effectiveGrowTimeMs = Math.floor(effectiveGrowTimeMs * 0.75)
+      const remainingMs = effectiveGrowTimeMs - elapsed
+      barPct            = Math.min(100, Math.floor((elapsed / effectiveGrowTimeMs) * 100))
+      const ws          = getWateringStatus(plot, now)
+      // Only show "Water in X" if the window opens before the crop finishes growing
+      const windowRelevant = ws.nextWindowInMs !== null && ws.nextWindowInMs < remainingMs
       if (ws.canWater) {
         midLabel    = 'Water now!'
         barColor    = C.blue
         borderColor = { r: 0.30, g: 0.50, b: 0.90, a: 0.95 }
         midColor    = C.blue
-      } else if (ws.nextWindowInMs !== null) {
-        midLabel    = `Water in ${formatTime(ws.nextWindowInMs)}`
+      } else if (windowRelevant) {
+        midLabel    = `Water in ${formatTime(ws.nextWindowInMs!)}`
         barColor    = C.gold
         borderColor = CARD_BORDER
         midColor    = CARD_TEXT_MUTE
       } else {
-        midLabel    = formatTime(def.growTimeMs - elapsed)
+        midLabel    = formatTime(remainingMs)
         barColor    = C.gold
         borderColor = CARD_BORDER
         midColor    = CARD_TEXT_MUTE
@@ -299,32 +335,37 @@ const PlotTile = ({ entity, idx, now }: TileProps) => {
     }
   }
 
+  const mob  = isMobile()
+  const icon = mob ? MOB_CARD_ICON   : CARD_ICON
+  const barH = mob ? MOB_BAR_H       : BAR_H
+  const barR = mob ? MOB_BAR_RADIUS  : BAR_RADIUS
+
   return (
     <FarmCard borderColor={borderColor}>
       <UiEntity
-        uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(8) }, flexShrink: 0 }}
+        uiTransform={{ width: icon, height: icon, margin: { bottom: ss(8) }, flexShrink: 0 }}
         uiBackground={{
           texture: { src: imgSrc !== '' ? imgSrc : SOIL_ICON, wrapMode: 'clamp' },
           textureMode: 'stretch',
         }}
       />
-      <Label value={topLabel} fontSize={ss(21)} color={CARD_TEXT} textAlign="middle-center" />
-      <Label value={midLabel} fontSize={ss(18)} color={midColor} textAlign="middle-center"
-        uiTransform={{ margin: { top: ss(4) } }} />
+      <Label value={topLabel} fontSize={mob ? ss(26) : ss(21)} color={CARD_TEXT} textAlign="middle-center" />
+      <Label value={midLabel} fontSize={mob ? ss(26) : ss(23)} color={midColor} textAlign="middle-center"
+        uiTransform={{ margin: { top: ss(6) } }} />
 
       {plot.isUnlocked && plot.cropType !== -1 && (
         <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', margin: { top: ss(8) } }}>
           <UiEntity
-            uiTransform={{ width: '100%', height: BAR_H, borderRadius: BAR_RADIUS }}
+            uiTransform={{ width: '100%', height: barH, borderRadius: barR }}
             uiBackground={{ color: { r: 0.12, g: 0.08, b: 0.04, a: 1 } }}
           >
             <UiEntity
-              uiTransform={{ width: `${barPct}%`, height: '100%', borderRadius: BAR_RADIUS }}
+              uiTransform={{ width: `${barPct}%`, height: '100%', borderRadius: barR }}
               uiBackground={{ color: barColor }}
             />
           </UiEntity>
           {subLabel !== '' && (
-            <Label value={subLabel} fontSize={ss(15)} color={CARD_TEXT_MUTE} textAlign="middle-center"
+            <Label value={subLabel} fontSize={mob ? ss(26) : ss(19)} color={CARD_TEXT_MUTE} textAlign="middle-center"
               uiTransform={{ margin: { top: ss(4) } }} />
           )}
         </UiEntity>
@@ -335,12 +376,12 @@ const PlotTile = ({ entity, idx, now }: TileProps) => {
         const fertDef = FERTILIZER_DATA.get(plot.fertilizerType as FertilizerType)
         if (!fertDef) return null
         return (
-          <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { top: ss(6) } }}>
+          <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { top: ss(8) } }}>
             <UiEntity
-              uiTransform={{ width: ss(20), height: ss(20), margin: { right: ss(5) }, flexShrink: 0 }}
+              uiTransform={{ width: mob ? ss(26) : ss(20), height: mob ? ss(26) : ss(20), margin: { right: ss(8) }, flexShrink: 0 }}
               uiBackground={{ texture: { src: fertDef.iconSrc, wrapMode: 'clamp' }, textureMode: 'stretch' }}
             />
-            <Label value={fertDef.name} fontSize={ss(13)} color={{ r: 0.3, g: 0.75, b: 0.2, a: 1 }} textAlign="middle-center" />
+            <Label value={fertDef.name} fontSize={mob ? ss(26) : ss(17)} color={{ r: 0.3, g: 0.75, b: 0.2, a: 1 }} textAlign="middle-center" />
           </UiEntity>
         )
       })()}
@@ -385,18 +426,25 @@ function addCompostWaste() {
 
 const BTN_BG_ON  = { r: 0.45, g: 0.26, b: 0.06, a: 1 }
 const BTN_BG_OFF = { r: 0.30, g: 0.22, b: 0.10, a: 1 }
-const BTN_TEXT   = { r: 0.97, g: 0.90, b: 0.68, a: 1 }
+const BTN_TEXT     = { r: 0.97, g: 0.90, b: 0.68, a: 1 }
+const MOB_BTN_TEXT = { r: 1, g: 1, b: 1, a: 1 }
+
+const COMPOST_FILL = { r: 0.18, g: 0.11, b: 0.04, a: 0.92 }
+const WHITE        = { r: 1, g: 1, b: 1, a: 1 }
+const WHITE_MUTE   = { r: 1, g: 1, b: 1, a: 0.65 }
+const WHITE_DIM    = { r: 1, g: 1, b: 1, a: 0.35 }
 
 const CompostTab = () => {
+  const mobile = isMobile()
+
   if (!playerState.compostBinUnlocked) {
-    return (
+    return mobile ? (
+      <UiEntity uiTransform={{ flex: 1, alignItems: 'center', justifyContent: 'center', width: '100%', padding: { left: ss(20), right: ss(20) } }}>
+        <Label value="Compost Bin not unlocked — buy it in the Store under the Fertilizers tab." fontSize={ss(26)} color={WHITE} textAlign="middle-center" />
+      </UiEntity>
+    ) : (
       <FarmCard height={ss(140)} borderColor={CARD_BORDER}>
-        <Label
-          value="Compost Bin not unlocked — buy it in the Store under the Fertilizers tab."
-          fontSize={ss(20)}
-          color={CARD_TEXT_MUTE}
-          textAlign="middle-center"
-        />
+        <Label value="Compost Bin not unlocked — buy it in the Store under the Fertilizers tab." fontSize={ss(18)} color={CARD_TEXT_MUTE} textAlign="middle-center" />
       </FarmCard>
     )
   }
@@ -404,21 +452,91 @@ const CompostTab = () => {
   const { wasteInBin, cyclesDone, nextCycleMs } = getCompostPanelState()
   const canAdd     = playerState.organicWaste > 0
   const canCollect = cyclesDone > 0
+  const statusBorder = canCollect ? { r: 0.82, g: 0.69, b: 0.20, a: 0.95 } : CARD_BORDER
 
+  if (mobile) {
+    return (
+      <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', alignItems: 'center' }}>
+
+        {/* Status card — full width, dark background */}
+        <UiEntity
+          uiTransform={{
+            flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+            width: '100%', height: ss(200),
+            margin: { bottom: ss(20) },
+            padding: { top: MOB_CARD_PAD_V, bottom: MOB_CARD_PAD_V, left: MOB_CARD_PAD_H, right: MOB_CARD_PAD_H },
+          }}
+          uiBackground={{ color: COMPOST_FILL }}
+        >
+          <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: ss(10) } }}>
+            <UiEntity
+              uiTransform={{ width: ss(40), height: ss(40), margin: { right: ss(10) }, flexShrink: 0 }}
+              uiBackground={{ texture: { src: ORGANIC_WASTE_ICON, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+            />
+            <Label value={`Hand: ${playerState.organicWaste}  ·  Bin: ${wasteInBin}`} fontSize={ss(26)} color={WHITE} />
+          </UiEntity>
+          {nextCycleMs !== null && (
+            <Label value={`Next fertilizer: ${formatTime(nextCycleMs)}`} fontSize={ss(26)} color={C.green} uiTransform={{ margin: { bottom: ss(6) } }} />
+          )}
+          {wasteInBin === 0 && (
+            <Label value="Add waste to start composting" fontSize={ss(26)} color={WHITE_MUTE} />
+          )}
+          {canCollect && (
+            <Label value={`${cyclesDone} fertilizer${cyclesDone > 1 ? 's' : ''} ready!`} fontSize={ss(26)} color={C.gold} />
+          )}
+        </UiEntity>
+
+        {/* Action buttons */}
+        <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', width: '100%', margin: { bottom: ss(28) } }}>
+          <UiEntity
+            uiTransform={{ width: ss(220), height: ss(64), alignItems: 'center', justifyContent: 'center', margin: { right: ss(20) } }}
+            uiBackground={{ color: canAdd ? BTN_BG_ON : BTN_BG_OFF }}
+            onMouseDown={canAdd ? () => { if (isZooming('fp_compost_add')) return; triggerCardZoom('fp_compost_add'); setTimeout(addCompostWaste, 290) } : undefined}
+          >
+            <Label value="Add Waste" fontSize={ss(26)} color={canAdd ? MOB_BTN_TEXT : WHITE_DIM} textAlign="middle-center" />
+          </UiEntity>
+          <UiEntity
+            uiTransform={{ width: Math.round(ss(220) * getZoomScale('fp_compost_collect')), height: Math.round(ss(64) * getZoomScale('fp_compost_collect')), alignItems: 'center', justifyContent: 'center' }}
+            uiBackground={{ color: canCollect ? { r: 0.55, g: 0.38, b: 0.05, a: 1 } : BTN_BG_OFF }}
+            onMouseDown={canCollect ? () => { if (isZooming('fp_compost_collect')) return; triggerCardZoom('fp_compost_collect'); setTimeout(collectCompostReady, 290) } : undefined}
+          >
+            <Label value={canCollect ? `Collect (${cyclesDone})` : 'Nothing ready'} fontSize={ss(26)} color={canCollect ? MOB_BTN_TEXT : WHITE_DIM} textAlign="middle-center" />
+          </UiEntity>
+        </UiEntity>
+
+        {/* Fertilizer inventory */}
+        <Label value="Your Fertilizers" fontSize={ss(28)} color={WHITE} uiTransform={{ margin: { bottom: ss(12) } }} />
+        <UiEntity uiTransform={{ flexDirection: 'row', flexWrap: 'wrap', width: '100%', justifyContent: 'center' }}>
+          {ALL_FERTILIZER_TYPES.map((ft) => {
+            const def   = FERTILIZER_DATA.get(ft)!
+            const count = playerState.fertilizers.get(ft) ?? 0
+            return (
+              <FarmCard key={ft} height={ss(200)} fillColor={COMPOST_FILL} borderColor={count > 0 ? { r: 0.82, g: 0.69, b: 0.39, a: 0.7 } : { r: 0.40, g: 0.30, b: 0.18, a: 0.4 }}>
+                <UiEntity
+                  uiTransform={{ width: ss(64), height: ss(64), margin: { bottom: ss(8) } }}
+                  uiBackground={{ texture: { src: def.iconSrc, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+                />
+                <Label value={def.name} fontSize={ss(26)} color={WHITE} textAlign="middle-center" />
+                <Label value={`x${count}`} fontSize={ss(26)} color={count > 0 ? C.green : WHITE_MUTE} textAlign="middle-center" />
+              </FarmCard>
+            )
+          })}
+        </UiEntity>
+      </UiEntity>
+    )
+  }
+
+  // Desktop layout
   return (
     <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
-
-      {/* Status + action row */}
       <UiEntity uiTransform={{ flexDirection: 'row', width: '100%', margin: { bottom: ss(16) }, alignItems: 'center' }}>
-
-        {/* Status card */}
-        <FarmCard height={ss(160)} borderColor={canCollect ? { r: 0.82, g: 0.69, b: 0.20, a: 0.95 } : CARD_BORDER}>
+        <FarmCard height={ss(160)} borderColor={statusBorder}>
           <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: ss(8) } }}>
             <UiEntity
               uiTransform={{ width: ss(36), height: ss(36), margin: { right: ss(8) }, flexShrink: 0 }}
               uiBackground={{ texture: { src: ORGANIC_WASTE_ICON, wrapMode: 'clamp' }, textureMode: 'stretch' }}
             />
-            <Label value={`Hand: ${playerState.organicWaste}  Bin: ${wasteInBin}`} fontSize={ss(18)} color={CARD_TEXT} />
+            <Label value={`Hand: ${playerState.organicWaste}  ·  Bin: ${wasteInBin}`} fontSize={ss(18)} color={CARD_TEXT} />
           </UiEntity>
           {nextCycleMs !== null && (
             <Label value={`Next fert: ${formatTime(nextCycleMs)}`} fontSize={ss(16)} color={C.green} uiTransform={{ margin: { bottom: ss(4) } }} />
@@ -430,8 +548,6 @@ const CompostTab = () => {
             <Label value={`${cyclesDone} fertilizer${cyclesDone > 1 ? 's' : ''} ready!`} fontSize={ss(17)} color={C.gold} />
           )}
         </FarmCard>
-
-        {/* Action buttons */}
         <UiEntity uiTransform={{ flexDirection: 'column', margin: { left: ss(12) } }}>
           <UiEntity
             uiTransform={{ width: ss(200), height: ss(52), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { bottom: ss(10) } }}
@@ -445,17 +561,10 @@ const CompostTab = () => {
             uiBackground={{ color: canCollect ? { r: 0.55, g: 0.38, b: 0.05, a: 1 } : BTN_BG_OFF }}
             onMouseDown={canCollect ? () => { if (isZooming('fp_compost_collect')) return; triggerCardZoom('fp_compost_collect'); setTimeout(collectCompostReady, 290) } : undefined}
           >
-            <Label
-              value={canCollect ? `Collect (${cyclesDone})` : 'Nothing ready'}
-              fontSize={ss(19)}
-              color={canCollect ? BTN_TEXT : CARD_TEXT_MUTE}
-              textAlign="middle-center"
-            />
+            <Label value={canCollect ? `Collect (${cyclesDone})` : 'Nothing ready'} fontSize={ss(19)} color={canCollect ? BTN_TEXT : CARD_TEXT_MUTE} textAlign="middle-center" />
           </UiEntity>
         </UiEntity>
       </UiEntity>
-
-      {/* Fertilizer inventory */}
       <Label value="Your Fertilizers" fontSize={ss(22)} color={CARD_TEXT} uiTransform={{ margin: { bottom: ss(10) } }} />
       <UiEntity uiTransform={{ flexDirection: 'row', flexWrap: 'wrap', width: '100%' }}>
         {ALL_FERTILIZER_TYPES.map((ft) => {
@@ -479,6 +588,7 @@ const CompostTab = () => {
 
 // ─── Main panel ───────────────────────────────────────────────────────────────
 export const FarmPanel = () => {
+  const mob          = isMobile()
   const soilEntities = getSoilEntities()
   const now          = Date.now()
 
@@ -492,8 +602,9 @@ export const FarmPanel = () => {
   const isPlotTab = tab === 'home' || tab === 'expansion'
   const plots     = tab === 'expansion' ? expansionPlots : homePlots
   const page      = isPlotTab ? farmPage[tab as 'home' | 'expansion'] : 0
-  const lastPage  = Math.max(0, Math.ceil(plots.length / PLOTS_PER_PAGE) - 1)
-  const pageSlice = plots.slice(page * PLOTS_PER_PAGE, (page + 1) * PLOTS_PER_PAGE)
+  const ppp       = mob ? MOB_PLOTS_PER_PAGE : PLOTS_PER_PAGE
+  const lastPage  = Math.max(0, Math.ceil(plots.length / ppp) - 1)
+  const pageSlice = plots.slice(page * ppp, (page + 1) * ppp)
   const offset    = tab === 'expansion' ? 12 : 0
 
   return (
@@ -504,34 +615,76 @@ export const FarmPanel = () => {
       {/* Compost tab */}
       {tab === 'compost' && <CompostTab />}
 
-      {/* Plot grid */}
-      {isPlotTab && (
+      {/* Plot grid — mobile: cards + pagination both pinned from the bottom */}
+      {isPlotTab && mob && (
+        <UiEntity uiTransform={{ width: '100%', height: MOB_PLOT_AREA_H }}>
+          {/* Cards absolutely positioned above pagination */}
+          <UiEntity
+            uiTransform={{
+              positionType: 'absolute',
+              position: { bottom: lastPage > 0 ? ss(160) : ss(120), left: 0 },
+              width: '100%',
+              flexDirection: 'row',
+              justifyContent: 'center',
+            }}
+          >
+            {pageSlice.map((e, i) => (
+              <PlotTile key={page * ppp + i} entity={e} idx={offset + page * ppp + i} now={now} />
+            ))}
+          </UiEntity>
+          {/* Pagination pinned to the very bottom */}
+          {lastPage > 0 && (
+            <UiEntity
+              uiTransform={{
+                positionType: 'absolute',
+                position: { bottom: ss(20), left: 0 },
+                width: '100%',
+                height: ss(64),
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <UiEntity
+                uiTransform={{ width: ss(200), height: ss(64), alignItems: 'center', justifyContent: 'center', borderRadius: 12, margin: { right: ss(24) } }}
+                uiBackground={{ color: page > 0 ? BTN_BG_ON : BTN_BG_OFF }}
+                onMouseDown={() => { if (farmPage[tab as 'home' | 'expansion'] > 0) farmPage[tab as 'home' | 'expansion']-- }}
+              >
+                <Label value="< Prev" fontSize={ss(26)} color={page > 0 ? MOB_BTN_TEXT : { r: 1, g: 1, b: 1, a: 0.35 }} textAlign="middle-center" />
+              </UiEntity>
+              <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={ss(26)} color={MOB_BTN_TEXT} textAlign="middle-center" uiTransform={{ width: ss(100) }} />
+              <UiEntity
+                uiTransform={{ width: ss(200), height: ss(64), alignItems: 'center', justifyContent: 'center', borderRadius: 12, margin: { left: ss(24) } }}
+                uiBackground={{ color: page < lastPage ? BTN_BG_ON : BTN_BG_OFF }}
+                onMouseDown={() => { if (farmPage[tab as 'home' | 'expansion'] < lastPage) farmPage[tab as 'home' | 'expansion']++ }}
+              >
+                <Label value="Next >" fontSize={ss(26)} color={page < lastPage ? MOB_BTN_TEXT : { r: 1, g: 1, b: 1, a: 0.35 }} textAlign="middle-center" />
+              </UiEntity>
+            </UiEntity>
+          )}
+        </UiEntity>
+      )}
+
+      {/* Plot grid — desktop: 8 per page, wrapping rows, inline pagination */}
+      {isPlotTab && !mob && (
         <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', flex: 1 }}>
           <UiEntity uiTransform={{ flexDirection: 'row', flexWrap: 'wrap', width: '100%', alignContent: 'flex-start', justifyContent: 'center', flex: 1 }}>
             {pageSlice.map((e, i) => (
-              <PlotTile key={page * PLOTS_PER_PAGE + i} entity={e} idx={offset + page * PLOTS_PER_PAGE + i} now={now} />
+              <PlotTile key={page * ppp + i} entity={e} idx={offset + page * ppp + i} now={now} />
             ))}
           </UiEntity>
-
-          {/* Pagination */}
           {lastPage > 0 && (
-            <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%', margin: { top: ss(12) }, flexShrink: 0 }}>
+            <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', width: '100%', flexShrink: 0, margin: { top: ss(10) } }}>
               <UiEntity
-                uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { right: ss(20) } }}
+                uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { right: ss(14) } }}
                 uiBackground={{ color: page > 0 ? BTN_BG_ON : BTN_BG_OFF }}
                 onMouseDown={() => { if (farmPage[tab as 'home' | 'expansion'] > 0) farmPage[tab as 'home' | 'expansion']-- }}
               >
                 <Label value="< Prev" fontSize={ss(18)} color={page > 0 ? BTN_TEXT : CARD_TEXT_MUTE} textAlign="middle-center" />
               </UiEntity>
-              <Label
-                value={`${page + 1} / ${lastPage + 1}`}
-                fontSize={ss(18)}
-                color={CARD_TEXT_MUTE}
-                textAlign="middle-center"
-                uiTransform={{ width: ss(80) }}
-              />
+              <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={ss(18)} color={CARD_TEXT} textAlign="middle-center" uiTransform={{ width: ss(80) }} />
               <UiEntity
-                uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { left: ss(20) } }}
+                uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { left: ss(14) } }}
                 uiBackground={{ color: page < lastPage ? BTN_BG_ON : BTN_BG_OFF }}
                 onMouseDown={() => { if (farmPage[tab as 'home' | 'expansion'] < lastPage) farmPage[tab as 'home' | 'expansion']++ }}
               >

--- a/src/ui/InventoryPanel.tsx
+++ b/src/ui/InventoryPanel.tsx
@@ -84,14 +84,6 @@ const InvCard = ({
       }}
       uiBackground={{ color: CARD_FILL }}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: CARD_W, height: CARD_H }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
       {children}
     </UiEntity>
   )
@@ -164,40 +156,60 @@ const InventoryPanelFrame = ({
 )
 
 // ─── TabBar ───────────────────────────────────────────────────────────────────
-const TabBar = ({ tab, hasOther }: { tab: 'seeds' | 'harvested' | 'other'; hasOther: boolean }) => (
-  <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', width: '100%', margin: { bottom: ss(12) }, flexShrink: 0 }}>
-    {(['seeds', 'harvested', 'other'] as const).map((t) => {
-      if (t === 'other' && !hasOther) return null
-      const active = tab === t
-      const label  = t === 'seeds' ? 'Seeds' : t === 'harvested' ? 'Harvested' : 'Other Items'
-      return (
-        <UiEntity
-          key={t}
-          uiTransform={{ width: TAB_W, height: TAB_H, alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { right: TAB_GAP } }}
-          uiBackground={{ color: active ? { r: 0.45, g: 0.26, b: 0.06, a: 0.9 } : { r: 0.58, g: 0.38, b: 0.12, a: 0.72 } }}
-          onMouseDown={() => { playSound('buttonclick'); invTab.value = t }}
-        >
-          <Label value={label} fontSize={ss(20)} color={active ? { r: 0.97, g: 0.90, b: 0.68, a: 1 } : { r: 0.97, g: 0.90, b: 0.68, a: 0.65 }} textAlign="middle-center" />
-        </UiEntity>
-      )
-    })}
-  </UiEntity>
-)
+const TabBar = ({ tab, hasOther }: { tab: 'seeds' | 'harvested' | 'other'; hasOther: boolean }) => {
+  const mob = isMobile()
+  const tH  = mob ? ss(60)  : TAB_H
+  const tW  = mob ? ss(240) : TAB_W
+  const tG  = mob ? ss(12)  : TAB_GAP
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'row', justifyContent: 'center', width: '100%', margin: { bottom: ss(12) }, flexShrink: 0 }}>
+      {(['seeds', 'harvested', 'other'] as const).map((t) => {
+        if (t === 'other' && !hasOther) return null
+        const active = tab === t
+        const label  = t === 'seeds' ? 'Seeds' : t === 'harvested' ? 'Harvested' : 'Other Items'
+        return (
+          <UiEntity
+            key={t}
+            uiTransform={{ width: tW, height: tH, alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { right: tG } }}
+            uiBackground={{ color: active ? { r: 0.45, g: 0.26, b: 0.06, a: 0.9 } : { r: 0.58, g: 0.38, b: 0.12, a: 0.72 } }}
+            onMouseDown={() => { playSound('buttonclick'); invTab.value = t }}
+          >
+            <Label
+              value={label}
+              fontSize={mob ? ss(26) : ss(20)}
+              color={active
+                ? (mob ? { r: 1, g: 1, b: 1, a: 1 } : { r: 0.97, g: 0.90, b: 0.68, a: 1 })
+                : (mob ? { r: 1, g: 1, b: 1, a: 0.65 } : { r: 0.97, g: 0.90, b: 0.68, a: 0.65 })}
+              textAlign="middle-center"
+            />
+          </UiEntity>
+        )
+      })}
+    </UiEntity>
+  )
+}
 
 // ─── Empty state ─────────────────────────────────────────────────────────────
-const EmptyState = ({ message }: { message: string }) => (
-  <UiEntity uiTransform={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-    <Label value={message} fontSize={ss(22)} color={CARD_TEXT_MUTE} textAlign="middle-center" />
-  </UiEntity>
-)
+const EmptyState = ({ message }: { message: string }) => {
+  const mob = isMobile()
+  return (
+    <UiEntity uiTransform={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Label value={message} fontSize={mob ? ss(26) : ss(22)} color={mob ? { r: 1, g: 1, b: 1, a: 0.7 } : CARD_TEXT_MUTE} textAlign="middle-center" />
+    </UiEntity>
+  )
+}
 
 // ─── Main panel ───────────────────────────────────────────────────────────────
 export const InventoryPanel = () => {
+  const mob         = isMobile()
   const seedRows    = ALL_CROP_TYPES.filter((c) => (playerState.seeds.get(c)     ?? 0) > 0)
   const harvestRows = ALL_CROP_TYPES.filter((c) => (playerState.harvested.get(c) ?? 0) > 0)
   const fertRows    = ALL_FERTILIZER_TYPES.filter((f) => (playerState.fertilizers.get(f) ?? 0) > 0)
   const hasOther    = playerState.organicWaste > 0 || fertRows.length > 0
   const tab         = invTab.value
+  const labelColor  = mob ? { r: 1, g: 1, b: 1, a: 1 }    : CARD_TEXT
+  const labelFs     = mob ? ss(26) : ss(20)
+  const countFs     = mob ? ss(26) : ss(21)
 
   // Auto-switch if "other" tab selected but nothing there
   if (tab === 'other' && !hasOther) invTab.value = 'seeds'
@@ -219,8 +231,8 @@ export const InventoryPanel = () => {
                     uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(10) } }}
                     uiBackground={{ texture: { src: CROP_SEED_IMAGES[c], wrapMode: 'clamp' }, textureMode: 'stretch' }}
                   />
-                  <Label value={CROP_NAMES[c]} fontSize={ss(20)} color={CARD_TEXT} textAlign="middle-center" />
-                  <Label value={`x${playerState.seeds.get(c)}`} fontSize={ss(21)} color={C.green} textAlign="middle-center"
+                  <Label value={CROP_NAMES[c]} fontSize={labelFs} color={labelColor} textAlign="middle-center" />
+                  <Label value={`x${playerState.seeds.get(c)}`} fontSize={countFs} color={C.green} textAlign="middle-center"
                     uiTransform={{ margin: { top: ss(4) } }} />
                 </InvCard>
               ))}
@@ -240,8 +252,8 @@ export const InventoryPanel = () => {
                     uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(10) } }}
                     uiBackground={{ texture: { src: CROP_HARVEST_IMAGES[c], wrapMode: 'clamp' }, textureMode: 'stretch' }}
                   />
-                  <Label value={CROP_NAMES[c]} fontSize={ss(20)} color={CARD_TEXT} textAlign="middle-center" />
-                  <Label value={`x${playerState.harvested.get(c)}`} fontSize={ss(21)} color={C.orange} textAlign="middle-center"
+                  <Label value={CROP_NAMES[c]} fontSize={labelFs} color={labelColor} textAlign="middle-center" />
+                  <Label value={`x${playerState.harvested.get(c)}`} fontSize={countFs} color={C.orange} textAlign="middle-center"
                     uiTransform={{ margin: { top: ss(4) } }} />
                 </InvCard>
               ))}
@@ -259,8 +271,8 @@ export const InventoryPanel = () => {
                 uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(10) } }}
                 uiBackground={{ texture: { src: ORGANIC_WASTE_ICON, wrapMode: 'clamp' }, textureMode: 'stretch' }}
               />
-              <Label value="Organic Waste" fontSize={ss(18)} color={CARD_TEXT} textAlign="middle-center" />
-              <Label value={`x${playerState.organicWaste}`} fontSize={ss(21)} color={{ r: 0.75, g: 0.52, b: 0.18, a: 1 }} textAlign="middle-center"
+              <Label value="Organic Waste" fontSize={labelFs} color={labelColor} textAlign="middle-center" />
+              <Label value={`x${playerState.organicWaste}`} fontSize={countFs} color={{ r: 0.75, g: 0.52, b: 0.18, a: 1 }} textAlign="middle-center"
                 uiTransform={{ margin: { top: ss(4) } }} />
             </InvCard>
           )}
@@ -273,8 +285,8 @@ export const InventoryPanel = () => {
                   uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(10) } }}
                   uiBackground={{ texture: { src: def.iconSrc, wrapMode: 'clamp' }, textureMode: 'stretch' }}
                 />
-                <Label value={def.name} fontSize={ss(18)} color={CARD_TEXT} textAlign="middle-center" />
-                <Label value={`x${playerState.fertilizers.get(f)}`} fontSize={ss(21)} color={C.green} textAlign="middle-center"
+                <Label value={def.name} fontSize={labelFs} color={labelColor} textAlign="middle-center" />
+                <Label value={`x${playerState.fertilizers.get(f)}`} fontSize={countFs} color={C.green} textAlign="middle-center"
                   uiTransform={{ margin: { top: ss(4) } }} />
               </InvCard>
             )

--- a/src/ui/PigPenPanel.tsx
+++ b/src/ui/PigPenPanel.tsx
@@ -107,14 +107,6 @@ const PigCard = ({
       }}
       uiBackground={{ color: CARD_FILL }}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: CARD_W, height: CARD_H }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: CARD_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height: CARD_H }} uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
       {children}
     </UiEntity>
   )

--- a/src/ui/PlantMenu.tsx
+++ b/src/ui/PlantMenu.tsx
@@ -81,20 +81,12 @@ const SeedCard = ({ cropType, count }: { key?: string | number; cropType: CropTy
         setTimeout(() => plantSeed(entity, cropType), 290)
       }}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: W, height: H }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: W, height: FRAME_THICKNESS }} uiBackground={{ color: SEED_BORDER }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: W, height: FRAME_THICKNESS }} uiBackground={{ color: SEED_BORDER }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height: H }} uiBackground={{ color: SEED_BORDER }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height: H }} uiBackground={{ color: SEED_BORDER }} />
-        </UiEntity>
-      )}
       <UiEntity
         uiTransform={{ width: CARD_ICON, height: CARD_ICON, margin: { bottom: ss(10) }, flexShrink: 0 }}
         uiBackground={{ texture: { src: CROP_SEED_IMAGES[cropType], wrapMode: 'clamp' }, textureMode: 'stretch' }}
       />
-      <Label value={CROP_NAMES[cropType]} fontSize={ss(20)} color={CARD_TEXT} textAlign="middle-center" />
-      <Label value={`x${count}`} fontSize={ss(21)} color={SEED_COUNT} textAlign="middle-center"
+      <Label value={CROP_NAMES[cropType]} fontSize={mobile ? ss(26) : ss(20)} color={CARD_TEXT} textAlign="middle-center" />
+      <Label value={`x${count}`} fontSize={mobile ? ss(26) : ss(21)} color={SEED_COUNT} textAlign="middle-center"
         uiTransform={{ margin: { top: ss(4) } }} />
     </UiEntity>
   )
@@ -132,6 +124,7 @@ const PlantPanelFrame = ({ onClose, children }: { onClose: () => void; children?
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 export const PlantMenu = () => {
+  const mob       = isMobile()
   const available = ALL_CROP_TYPES.filter(
     (ct) => (playerState.seeds.get(ct) ?? 0) > 0 && playerState.unlockedCrops.has(ct),
   )
@@ -145,13 +138,13 @@ export const PlantMenu = () => {
     <PlantPanelFrame onClose={onClose}>
       {available.length === 0 ? (
         <UiEntity uiTransform={{ flex: 1, alignItems: 'center', justifyContent: 'center', flexDirection: 'column' }}>
-          <Label value="No seeds in inventory!" fontSize={ss(27)} color={CARD_TEXT_MUTE} textAlign="middle-center" />
-          <Label value="Visit the Seed Shop to buy some." fontSize={ss(20)} color={CARD_TEXT_MUTE} textAlign="middle-center"
+          <Label value="No seeds in inventory!" fontSize={mob ? ss(31) : ss(27)} color={mob ? { r: 1, g: 1, b: 1, a: 1 } : CARD_TEXT_MUTE} textAlign="middle-center" />
+          <Label value="Visit the Seed Shop to buy some." fontSize={mob ? ss(26) : ss(20)} color={mob ? { r: 1, g: 1, b: 1, a: 1 } : CARD_TEXT_MUTE} textAlign="middle-center"
             uiTransform={{ margin: { top: ss(12) } }} />
         </UiEntity>
       ) : (
         <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
-          <Label value="Choose a seed to plant:" fontSize={ss(21)} color={{ r: 0.97, g: 0.90, b: 0.68, a: 1 }}
+          <Label value="Choose a seed to plant:" fontSize={mob ? ss(28) : ss(21)} color={{ r: 0.97, g: 0.90, b: 0.68, a: 1 }}
             uiTransform={{ margin: { bottom: ss(14) } }} />
           <UiEntity uiTransform={{ flexDirection: 'row', flexWrap: 'wrap', width: '100%', alignContent: 'flex-start', justifyContent: 'center' }}>
             {available.map((ct) => (

--- a/src/ui/QuestPanel.tsx
+++ b/src/ui/QuestPanel.tsx
@@ -30,12 +30,12 @@ import { playSound } from '../systems/sfxSystem'
 const NPC_HEAD: Record<string, string> = {}
 for (const npc of NPC_ROSTER) NPC_HEAD[npc.id] = npc.headImage
 
-// ─── Atlas frame ─────────────────────────────────────────────────────────────
-const QUEST_ATLAS   = 'assets/images/ui_loading/quest_atlas.png'
-const ATLAS_SIZE    = 1024
-const BG_RECT       = { x: 57, y: 15, w: 909, h: 678 } as const
-const UI_SCALE      = 0.8
-const ss            = (v: number) => Math.round(v * UI_SCALE)
+// ─── Atlas ────────────────────────────────────────────────────────────────────
+const QUEST_ATLAS      = 'assets/images/ui_loading/quest_atlas.png'
+const ATLAS_SIZE       = 1024
+const BG_RECT          = { x: 57, y: 15, w: 909, h: 678 } as const
+const UI_SCALE         = 0.8
+const ss               = (v: number) => Math.round(v * UI_SCALE)
 
 const PANEL_W          = ss(1189)
 const PANEL_H          = Math.round((PANEL_W * BG_RECT.h) / BG_RECT.w)
@@ -45,25 +45,59 @@ const CONTENT_RIGHT    = ss(72)
 const CONTENT_TOP      = ss(100)
 const CONTENT_BOTTOM   = ss(68)
 const CONTENT_W        = PANEL_W - CONTENT_LEFT - CONTENT_RIGHT
+const CONTENT_H        = PANEL_H - CONTENT_TOP - CONTENT_BOTTOM
 const CLOSE_SIZE       = ss(74)
 const CLOSE_RIGHT      = ss(28)
 const CLOSE_TOP        = ss(16)
 
+// Mobile pagination bar (big buttons like farm)
+const MOB_PAGINAV_H    = ss(80)
+const DSK_PAGINAV_H    = ss(56)
+
 // ─── Palette ──────────────────────────────────────────────────────────────────
 const CARD_FILL      = { r: 0.95, g: 0.88, b: 0.70, a: 0.55 }
+const MOB_CARD_FILL  = { r: 0.18, g: 0.11, b: 0.04, a: 0.92 }
 const CARD_TEXT      = { r: 0.22, g: 0.12, b: 0.04, a: 1 }
 const CARD_TEXT_MUTE = { r: 0.45, g: 0.28, b: 0.10, a: 1 }
 const TRACK_COLOR    = { r: 0.55, g: 0.38, b: 0.15, a: 0.6 }
 const COIN_GOLD      = { r: 0.92, g: 0.72, b: 0.10, a: 1 }
-const REWARD_MUTE    = { r: 0.50, g: 0.32, b: 0.10, a: 1 }
-const FRAME_THICKNESS = 4
-
+const WHITE          = { r: 1, g: 1, b: 1, a: 1 }
+const WHITE_MUTE     = { r: 1, g: 1, b: 1, a: 0.65 }
+const WHITE_DIM      = { r: 1, g: 1, b: 1, a: 0.35 }
 const CARD_BORDER    = { r: 0.92, g: 0.72, b: 0.10, a: 0.95 }
 const COL_DONE       = { r: 0.30, g: 0.78, b: 0.30, a: 0.95 }
+const BTN_ON         = { r: 0.45, g: 0.26, b: 0.06, a: 1 }
+const BTN_OFF        = { r: 0.30, g: 0.22, b: 0.10, a: 1 }
+const BTN_TEXT       = { r: 0.97, g: 0.90, b: 0.68, a: 1 }
 
 type RGBA = { r: number; g: number; b: number; a: number }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── Debug: force all 11 items visible — DELETE BEFORE SHIP ──────────────────
+const QUEST_DEBUG = true
+
+// ─── Pagination + expand state ────────────────────────────────────────────────
+const questPage      = { value: 0 }
+const expandedQuests = new Set<string>()
+const ITEMS_PER_PAGE = 4
+
+// ─── Item types ───────────────────────────────────────────────────────────────
+type MilestoneItem = {
+  kind:       'milestone'
+  key:        string
+  title:      string
+  avatarSrc:  string
+  milestones: { label: string }[]
+  getStatus:  (m: any) => string
+}
+type QuestItem = {
+  kind: 'quest'
+  key:  string
+  def:  typeof QUEST_DEFINITIONS[number]
+  qp:   { current: number; status: string }
+}
+type AnyItem = MilestoneItem | QuestItem
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 function bgUvs(rect: { x: number; y: number; w: number; h: number }): number[] {
   const S = ATLAS_SIZE
   const l = rect.x / S, r = (rect.x + rect.w) / S
@@ -71,96 +105,52 @@ function bgUvs(rect: { x: number; y: number; w: number; h: number }): number[] {
   return [l, b, l, t, r, t, r, b]
 }
 
-// ─── QuestCard wrapper ────────────────────────────────────────────────────────
-const QuestCard = ({
-  borderColor,
-  children,
-}: {
-  key?: string
-  borderColor: RGBA
-  children?: ReactEcs.JSX.ReactNode
-}) => {
-  const mobile = isMobile()
+// ─── Single checklist item ────────────────────────────────────────────────────
+const ChecklistRow = ({ label, status, fontSize }: { key?: string; label: string; status: string; fontSize: number }) => {
+  const icon  = status === 'done' ? '✓' : status === 'current' ? '▶' : '○'
+  const color = status === 'done' ? COL_DONE : status === 'current' ? COIN_GOLD : WHITE_MUTE
   return (
-    <UiEntity
-      uiTransform={{
-        flexDirection: 'row',
-        width: '100%',
-        margin: { bottom: ss(16) },
-        borderWidth: 3,
-        borderColor,
-        borderRadius: 12,
-        overflow: 'hidden',
-      }}
-      uiBackground={{ color: CARD_FILL }}
-    >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: '100%', height: '100%' }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: CONTENT_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width: CONTENT_W, height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },    width: FRAME_THICKNESS, height: '100%' }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 },   width: FRAME_THICKNESS, height: '100%' }} uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
-      {children}
+    <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: ss(10) } }}>
+      <Label value={icon}  fontSize={fontSize} color={color} uiTransform={{ width: ss(28), flexShrink: 0 }} />
+      <Label value={label} fontSize={fontSize} color={color} />
     </UiEntity>
   )
 }
 
-// ─── Milestone checklist ──────────────────────────────────────────────────────
+// ─── Checklist — single column (desktop) or two columns (mobile) ──────────────
 const Checklist = ({
   milestones,
   getStatus,
 }: {
   milestones: { label: string }[]
-  getStatus: (m: any) => 'done' | 'current' | string
-}) => (
-  <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
-    {milestones.map((m) => {
-      const status = getStatus(m)
-      const icon  = status === 'done' ? '✓' : status === 'current' ? '▶' : '○'
-      const color = status === 'done' ? COL_DONE : status === 'current' ? COIN_GOLD : CARD_TEXT_MUTE
-      return (
-        <UiEntity
-          key={m.label}
-          uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: ss(9) } }}
-        >
-          <Label value={icon}    fontSize={ss(21)} color={color} uiTransform={{ width: ss(26) }} />
-          <Label value={m.label} fontSize={ss(21)} color={color} />
-        </UiEntity>
-      )
-    })}
-  </UiEntity>
-)
-
-// ─── Tutorial-style cards (Mayor + milestone list) ────────────────────────────
-const MilestoneCard = ({
-  title,
-  accent,
-  milestones,
-  getStatus,
-}: {
-  key?: string
-  title: string
-  accent: RGBA
-  milestones: { label: string }[]
   getStatus: (m: any) => string
 }) => {
-  const done = milestones.filter((m) => getStatus(m) === 'done').length
-  return (
-    <QuestCard borderColor={accent}>
-      <UiEntity
-        uiTransform={{ width: ss(80), height: ss(80), margin: { top: ss(18), bottom: ss(18), left: ss(18) }, flexShrink: 0 }}
-        uiBackground={{ texture: { src: MAYOR_DEF.headImage, wrapMode: 'clamp' }, textureMode: 'stretch' }}
-      />
-      <UiEntity uiTransform={{ flex: 1, flexDirection: 'column', padding: { top: ss(16), bottom: ss(16), left: ss(18), right: ss(16) } }}>
-        <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { bottom: ss(12) } }}>
-          <Label value={title}                            fontSize={ss(24)} color={CARD_TEXT} />
-          <Label value={`  ${done}/${milestones.length}`} fontSize={ss(20)} color={CARD_TEXT_MUTE} />
-        </UiEntity>
-        <Checklist milestones={milestones} getStatus={getStatus} />
+  const mob = isMobile()
+  const fs  = mob ? ss(26) : ss(20)
+
+  if (!mob) {
+    return (
+      <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
+        {milestones.map((m) => <ChecklistRow key={m.label} label={m.label} status={getStatus(m)} fontSize={fs} />)}
       </UiEntity>
-    </QuestCard>
+    )
+  }
+
+  // Mobile: two columns
+  const half  = Math.ceil(milestones.length / 2)
+  const left  = milestones.slice(0, half)
+  const right = milestones.slice(half)
+  const colW  = Math.floor((CONTENT_W - ss(44)) / 2)  // ~400px each
+
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'row', width: '100%' }}>
+      <UiEntity uiTransform={{ flexDirection: 'column', width: colW, margin: { right: ss(16) } }}>
+        {left.map((m) => <ChecklistRow key={m.label} label={m.label} status={getStatus(m)} fontSize={fs} />)}
+      </UiEntity>
+      <UiEntity uiTransform={{ flexDirection: 'column', width: colW }}>
+        {right.map((m) => <ChecklistRow key={m.label} label={m.label} status={getStatus(m)} fontSize={fs} />)}
+      </UiEntity>
+    </UiEntity>
   )
 }
 
@@ -170,12 +160,206 @@ const ProgressBar = ({ pct, fill }: { pct: number; fill: RGBA }) => (
     uiTransform={{ width: '100%', height: ss(12), borderRadius: ss(6), margin: { bottom: ss(6) }, overflow: 'hidden' }}
     uiBackground={{ color: TRACK_COLOR }}
   >
-    <UiEntity
-      uiTransform={{ width: `${pct}%`, height: '100%', borderRadius: ss(6) }}
-      uiBackground={{ color: fill }}
-    />
+    <UiEntity uiTransform={{ width: `${pct}%`, height: '100%', borderRadius: ss(6) }} uiBackground={{ color: fill }} />
   </UiEntity>
 )
+
+// ─── Expanded quest details ───────────────────────────────────────────────────
+const QuestExpanded = ({
+  def, qp,
+}: {
+  def: typeof QUEST_DEFINITIONS[number]
+  qp: { current: number; status: string }
+}) => {
+  const mob      = isMobile()
+  const pct      = Math.min(100, Math.floor((qp.current / def.target) * 100))
+  const isActive = qp.status === 'active'
+  const isDone   = qp.status === 'completed'
+
+  let questIcon = BOX_CROPS_ICON
+  if (def.type === 'harvest_crop' && def.cropType !== null) questIcon = CROP_HARVEST_IMAGES[def.cropType]
+  else if (def.type === 'water_total')  questIcon = WATERINGCAN_ICON
+  else if (def.type === 'plant_total')  questIcon = SOIL_ICON
+  else if (def.type === 'sell_total')   questIcon = SHOPINGCART_ICON
+
+  const textFs = mob ? ss(26) : ss(19)
+
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'row', padding: { left: ss(14), right: ss(14), bottom: ss(16) } }}>
+      <UiEntity
+        uiTransform={{ width: ss(52), height: ss(52), flexShrink: 0, margin: { right: ss(14) } }}
+        uiBackground={{ texture: { src: questIcon, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+      />
+      <UiEntity uiTransform={{ flexDirection: 'column', width: CONTENT_W - ss(52) - ss(14) - ss(28) }}>
+        {isActive && (
+          <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
+            <ProgressBar pct={pct} fill={CARD_BORDER} />
+            <Label value={`${qp.current} / ${def.target}`} fontSize={textFs} color={mob ? WHITE_MUTE : CARD_TEXT_MUTE} />
+          </UiEntity>
+        )}
+        {qp.status === 'claimable' && (
+          <Label value="Ready to Claim!" fontSize={mob ? ss(28) : ss(22)} color={COIN_GOLD} />
+        )}
+        {!isDone && (
+          <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { top: ss(10) } }}>
+            <UiEntity
+              uiTransform={{ width: ss(24), height: ss(24), margin: { right: ss(6) }, flexShrink: 0 }}
+              uiBackground={{ texture: { src: COINS_IMAGE, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+            />
+            <Label value={`${def.rewardCoins}`}    fontSize={mob ? ss(26) : ss(21)} color={COIN_GOLD} />
+            <Label value={`  +${def.rewardXp} XP`} fontSize={mob ? ss(26) : ss(19)} color={mob ? WHITE_MUTE : CARD_TEXT_MUTE} />
+          </UiEntity>
+        )}
+      </UiEntity>
+    </UiEntity>
+  )
+}
+
+// ─── Item row (header always visible, content expands on tap) ─────────────────
+const ItemRow = ({ item }: { key?: string; item: AnyItem }) => {
+  const mob      = isMobile()
+  const expanded = expandedQuests.has(item.key)
+
+  let avatarSrc   = ''
+  let title       = ''
+  let subtitle    = ''
+  let subtitleCol = mob ? WHITE_MUTE : CARD_TEXT_MUTE
+
+  if (item.kind === 'milestone') {
+    avatarSrc = item.avatarSrc
+    title     = item.title
+    const done = item.milestones.filter(m => item.getStatus(m) === 'done').length
+    subtitle   = `${done} / ${item.milestones.length} done`
+  } else {
+    const { def, qp } = item
+    avatarSrc = NPC_HEAD[def.npcId ?? def.id] ?? ''
+    title     = def.title
+    if (qp.status === 'claimable') {
+      subtitle    = 'Ready to claim!'
+      subtitleCol = COIN_GOLD
+    } else if (qp.status === 'completed') {
+      subtitle    = 'Completed ✓'
+      subtitleCol = COL_DONE
+    } else {
+      subtitle = `${qp.current} / ${def.target}`
+    }
+  }
+
+  const toggle = () => {
+    playSound('buttonclick')
+    if (expandedQuests.has(item.key)) expandedQuests.delete(item.key)
+    else expandedQuests.add(item.key)
+  }
+
+  // Middle width = card width - padding - avatar - chevron
+  const midW = CONTENT_W - ss(14) - ss(10) - ss(52) - ss(14) - ss(44)
+
+  return (
+    <UiEntity
+      uiTransform={{
+        flexDirection: 'column',
+        width: '100%',
+        margin: { bottom: ss(12) },
+        borderWidth: mob ? 0 : 3,
+        borderColor: CARD_BORDER,
+        borderRadius: mob ? 0 : 12,
+        overflow: 'hidden',
+      }}
+      uiBackground={{ color: mob ? MOB_CARD_FILL : CARD_FILL }}
+    >
+      {/* Collapsed header row */}
+      <UiEntity
+        uiTransform={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          width: '100%',
+          height: ss(76),
+          padding: { left: ss(14), right: ss(10) },
+        }}
+        onMouseDown={toggle}
+      >
+        <UiEntity
+          uiTransform={{ width: ss(52), height: ss(52), flexShrink: 0, margin: { right: ss(14) } }}
+          uiBackground={{ texture: { src: avatarSrc, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+        />
+        <UiEntity uiTransform={{ flexDirection: 'column', width: midW }}>
+          <Label value={title}    fontSize={mob ? ss(26) : ss(21)} color={mob ? WHITE : CARD_TEXT} />
+          <Label value={subtitle} fontSize={mob ? ss(26) : ss(19)} color={subtitleCol} uiTransform={{ margin: { top: ss(4) } }} />
+        </UiEntity>
+        <Label
+          value={expanded ? '▲' : '▼'}
+          fontSize={ss(22)}
+          color={mob ? WHITE_DIM : CARD_TEXT_MUTE}
+          uiTransform={{ width: ss(44), flexShrink: 0 }}
+          textAlign="middle-center"
+        />
+      </UiEntity>
+
+      {/* Expanded milestone content */}
+      {expanded && item.kind === 'milestone' && (
+        <UiEntity uiTransform={{ flexDirection: 'column', padding: { left: ss(14), right: ss(14), bottom: ss(16) } }}>
+          <Checklist milestones={item.milestones} getStatus={item.getStatus} />
+        </UiEntity>
+      )}
+
+      {/* Expanded quest content */}
+      {expanded && item.kind === 'quest' && (
+        <QuestExpanded def={item.def} qp={item.qp} />
+      )}
+    </UiEntity>
+  )
+}
+
+// ─── Pagination nav ───────────────────────────────────────────────────────────
+const QuestPageNav = ({ page, lastPage }: { page: number; lastPage: number }) => {
+  const mob     = isMobile()
+  const canPrev = page > 0
+  const canNext = page < lastPage
+
+  if (mob) {
+    const btnW = ss(200), btnH = ss(64)
+    return (
+      <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%', height: MOB_PAGINAV_H, flexShrink: 0 }}>
+        <UiEntity
+          uiTransform={{ width: btnW, height: btnH, alignItems: 'center', justifyContent: 'center', borderRadius: 12, margin: { right: ss(24) } }}
+          uiBackground={{ color: canPrev ? BTN_ON : BTN_OFF }}
+          onMouseDown={canPrev ? () => { playSound('buttonclick'); questPage.value-- } : undefined}
+        >
+          <Label value="< Prev" fontSize={ss(26)} color={canPrev ? WHITE : WHITE_DIM} textAlign="middle-center" />
+        </UiEntity>
+        <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={ss(26)} color={{ r: 1, g: 1, b: 1, a: 0.8 }} textAlign="middle-center" uiTransform={{ width: ss(100) }} />
+        <UiEntity
+          uiTransform={{ width: btnW, height: btnH, alignItems: 'center', justifyContent: 'center', borderRadius: 12, margin: { left: ss(24) } }}
+          uiBackground={{ color: canNext ? BTN_ON : BTN_OFF }}
+          onMouseDown={canNext ? () => { playSound('buttonclick'); questPage.value++ } : undefined}
+        >
+          <Label value="Next >" fontSize={ss(26)} color={canNext ? WHITE : WHITE_DIM} textAlign="middle-center" />
+        </UiEntity>
+      </UiEntity>
+    )
+  }
+
+  const disabledCol = CARD_TEXT_MUTE
+  return (
+    <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%', height: DSK_PAGINAV_H, flexShrink: 0 }}>
+      <UiEntity
+        uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { right: ss(20) } }}
+        uiBackground={{ color: canPrev ? BTN_ON : BTN_OFF }}
+        onMouseDown={canPrev ? () => { playSound('buttonclick'); questPage.value-- } : undefined}
+      >
+        <Label value="< Prev" fontSize={ss(22)} color={canPrev ? BTN_TEXT : disabledCol} textAlign="middle-center" />
+      </UiEntity>
+      <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={ss(22)} color={CARD_TEXT_MUTE} textAlign="middle-center" uiTransform={{ width: ss(90), height: ss(44) }} />
+      <UiEntity
+        uiTransform={{ width: ss(130), height: ss(44), alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { left: ss(20) } }}
+        uiBackground={{ color: canNext ? BTN_ON : BTN_OFF }}
+        onMouseDown={canNext ? () => { playSound('buttonclick'); questPage.value++ } : undefined}
+      >
+        <Label value="Next >" fontSize={ss(22)} color={canNext ? BTN_TEXT : disabledCol} textAlign="middle-center" />
+      </UiEntity>
+    </UiEntity>
+  )
+}
 
 // ─── Panel frame ─────────────────────────────────────────────────────────────
 const QuestPanelFrame = ({ onClose, children }: { onClose: () => void; children?: ReactEcs.JSX.ReactNode }) => (
@@ -192,7 +376,7 @@ const QuestPanelFrame = ({ onClose, children }: { onClose: () => void; children?
           positionType: 'absolute',
           position: { left: CONTENT_LEFT, top: CONTENT_TOP },
           width: CONTENT_W,
-          height: PANEL_H - CONTENT_TOP - CONTENT_BOTTOM,
+          height: CONTENT_H,
           flexDirection: 'column',
           overflow: 'hidden',
         }}
@@ -209,105 +393,62 @@ const QuestPanelFrame = ({ onClose, children }: { onClose: () => void; children?
 
 // ─── Main panel ───────────────────────────────────────────────────────────────
 export const QuestPanel = () => {
-  const visible = QUEST_DEFINITIONS.filter((d) => {
-    const qp = questProgressMap.get(d.id)
-    return qp && qp.status !== 'available' && qp.status !== 'completed'
-  })
+  const mob       = isMobile()
+  const paginH    = mob ? MOB_PAGINAV_H : DSK_PAGINAV_H
+  const listH     = CONTENT_H - paginH
 
-  const hasAnything =
-    tutorialState.active ||
-    progressionEventState.active ||
-    animalTutorialState.chickenActive ||
-    animalTutorialState.pigActive ||
-    visible.length > 0
+  // Build unified item list
+  const items: AnyItem[] = []
+
+  if (QUEST_DEBUG || tutorialState.active) {
+    items.push({ kind: 'milestone', key: 'tutorial', title: 'Tutorial', avatarSrc: MAYOR_DEF.headImage, milestones: TUTORIAL_MILESTONES, getStatus: getTutorialMilestoneStatus })
+  }
+  if (QUEST_DEBUG || progressionEventState.active) {
+    items.push({ kind: 'milestone', key: 'fert', title: 'Fertilizer Tutorial', avatarSrc: MAYOR_DEF.headImage, milestones: PROGRESSION_MILESTONES, getStatus: getProgressionMilestoneStatus })
+  }
+  if (QUEST_DEBUG || animalTutorialState.chickenActive) {
+    items.push({ kind: 'milestone', key: 'chicken', title: 'Chicken Tutorial', avatarSrc: MAYOR_DEF.headImage, milestones: CHICKEN_MILESTONES, getStatus: getChickenMilestoneStatus })
+  }
+  if (QUEST_DEBUG || animalTutorialState.pigActive) {
+    items.push({ kind: 'milestone', key: 'pig', title: 'Pig Tutorial', avatarSrc: MAYOR_DEF.headImage, milestones: PIG_MILESTONES, getStatus: getPigMilestoneStatus })
+  }
+
+  if (QUEST_DEBUG) {
+    for (const def of QUEST_DEFINITIONS) {
+      items.push({ kind: 'quest', key: def.id, def, qp: { current: Math.floor(def.target / 2), status: 'active' } })
+    }
+  } else {
+    for (const def of QUEST_DEFINITIONS) {
+      const qp = questProgressMap.get(def.id)
+      if (qp && qp.status !== 'available' && qp.status !== 'completed') {
+        items.push({ kind: 'quest', key: def.id, def, qp })
+      }
+    }
+  }
+
+  const page     = questPage.value
+  const lastPage = Math.max(0, Math.ceil(items.length / ITEMS_PER_PAGE) - 1)
+  if (page > lastPage) questPage.value = lastPage
+  const pageSlice = items.slice(page * ITEMS_PER_PAGE, (page + 1) * ITEMS_PER_PAGE)
 
   return (
     <QuestPanelFrame onClose={() => { playerState.activeMenu = 'none' }}>
 
-      {!hasAnything && (
-        <UiEntity uiTransform={{ flex: 1, alignItems: 'center', justifyContent: 'center', flexDirection: 'column' }}>
-          <Label value="No active quests" fontSize={ss(27)} color={CARD_TEXT_MUTE} textAlign="middle-center" />
-          <Label value="Talk to villagers to receive quests!" fontSize={ss(20)} color={CARD_TEXT_MUTE} textAlign="middle-center"
-            uiTransform={{ margin: { top: ss(12) } }} />
-        </UiEntity>
-      )}
+      {/* Quest list — scrollable within the page in case expanded items overflow */}
+      <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', height: listH, overflow: 'scroll' }}>
+        {items.length === 0 && (
+          <UiEntity uiTransform={{ flexDirection: 'column', width: '100%', alignItems: 'center', margin: { top: ss(80) } }}>
+            <Label value="No active quests" fontSize={ss(27)} color={mob ? WHITE_MUTE : CARD_TEXT_MUTE} textAlign="middle-center" />
+            <Label value="Talk to villagers to receive quests!" fontSize={ss(20)} color={mob ? WHITE_MUTE : CARD_TEXT_MUTE} textAlign="middle-center"
+              uiTransform={{ margin: { top: ss(12) } }} />
+          </UiEntity>
+        )}
+        {pageSlice.map((item) => <ItemRow key={item.key} item={item} />)}
+      </UiEntity>
 
-      {tutorialState.active && (
-        <MilestoneCard key="tutorial" title="Tutorial" accent={CARD_BORDER}
-          milestones={TUTORIAL_MILESTONES} getStatus={getTutorialMilestoneStatus} />
-      )}
+      {/* Pagination — always shown at bottom */}
+      <QuestPageNav page={page} lastPage={lastPage} />
 
-      {progressionEventState.active && (
-        <MilestoneCard key="fert" title="Fertilizer Tutorial" accent={CARD_BORDER}
-          milestones={PROGRESSION_MILESTONES} getStatus={getProgressionMilestoneStatus} />
-      )}
-
-      {animalTutorialState.chickenActive && (
-        <MilestoneCard key="chicken" title="Chicken Tutorial" accent={CARD_BORDER}
-          milestones={CHICKEN_MILESTONES} getStatus={getChickenMilestoneStatus} />
-      )}
-
-      {animalTutorialState.pigActive && (
-        <MilestoneCard key="pig" title="Pig Tutorial" accent={CARD_BORDER}
-          milestones={PIG_MILESTONES} getStatus={getPigMilestoneStatus} />
-      )}
-
-      {visible.map((def) => {
-        const qp       = questProgressMap.get(def.id)!
-        const pct      = Math.min(100, Math.floor((qp.current / def.target) * 100))
-        const isDone   = qp.status === 'completed'
-        const isActive = qp.status === 'active'
-        const border   = CARD_BORDER
-
-        let questIcon = BOX_CROPS_ICON
-        if (def.type === 'harvest_crop' && def.cropType !== null) questIcon = CROP_HARVEST_IMAGES[def.cropType]
-        else if (def.type === 'water_total') questIcon = WATERINGCAN_ICON
-        else if (def.type === 'plant_total') questIcon = SOIL_ICON
-        else if (def.type === 'sell_total') questIcon = SHOPINGCART_ICON
-
-        return (
-          <QuestCard key={def.id} borderColor={border}>
-            {/* NPC portrait */}
-            <UiEntity
-              uiTransform={{ width: ss(86), height: ss(86), margin: { top: ss(18), bottom: ss(18), left: ss(18) }, flexShrink: 0 }}
-              uiBackground={{ texture: { src: NPC_HEAD[def.id] ?? '', wrapMode: 'clamp' }, textureMode: 'stretch' }}
-            />
-
-            {/* Content */}
-            <UiEntity uiTransform={{ flex: 1, flexDirection: 'column', padding: { top: ss(16), bottom: ss(16), left: ss(18), right: ss(14) } }}>
-              <Label value={def.npcName} fontSize={ss(19)} color={REWARD_MUTE} uiTransform={{ margin: { bottom: ss(5) } }} />
-              <Label value={def.title}   fontSize={ss(25)} color={CARD_TEXT}   uiTransform={{ margin: { bottom: ss(12) } }} />
-
-              {isActive && (
-                <UiEntity uiTransform={{ flexDirection: 'column', width: '100%' }}>
-                  <ProgressBar pct={pct} fill={CARD_BORDER} />
-                  <Label value={`${qp.current} / ${def.target}`} fontSize={ss(19)} color={CARD_TEXT_MUTE} />
-                </UiEntity>
-              )}
-              {!isActive && (
-                <Label value={isDone ? 'Completed ✓' : 'Ready to Claim!'} fontSize={ss(22)}
-                  color={isDone ? COL_DONE : COIN_GOLD} />
-              )}
-              {!isDone && (
-                <UiEntity uiTransform={{ flexDirection: 'row', alignItems: 'center', margin: { top: ss(12) } }}>
-                  <UiEntity
-                    uiTransform={{ width: ss(24), height: ss(24), margin: { right: ss(7) }, flexShrink: 0 }}
-                    uiBackground={{ texture: { src: COINS_IMAGE, wrapMode: 'clamp' }, textureMode: 'stretch' }}
-                  />
-                  <Label value={`${def.rewardCoins}`}     fontSize={ss(22)} color={COIN_GOLD} />
-                  <Label value={`  +${def.rewardXp} XP`}  fontSize={ss(20)} color={CARD_TEXT_MUTE} />
-                </UiEntity>
-              )}
-            </UiEntity>
-
-            {/* Quest icon */}
-            <UiEntity
-              uiTransform={{ width: ss(78), height: ss(78), margin: { top: ss(18), bottom: ss(18), right: ss(18) }, flexShrink: 0 }}
-              uiBackground={{ texture: { src: questIcon, wrapMode: 'clamp' }, textureMode: 'stretch' }}
-            />
-          </QuestCard>
-        )
-      })}
     </QuestPanelFrame>
   )
 }

--- a/src/ui/QuestPanel.tsx
+++ b/src/ui/QuestPanel.tsx
@@ -72,8 +72,7 @@ const BTN_TEXT       = { r: 0.97, g: 0.90, b: 0.68, a: 1 }
 
 type RGBA = { r: number; g: number; b: number; a: number }
 
-// ─── Debug: force all 11 items visible — DELETE BEFORE SHIP ──────────────────
-const QUEST_DEBUG = true
+const QUEST_DEBUG = false
 
 // ─── Pagination + expand state ────────────────────────────────────────────────
 const questPage      = { value: 0 }

--- a/src/ui/ShopMenu.tsx
+++ b/src/ui/ShopMenu.tsx
@@ -123,26 +123,6 @@ const ShopCardFrame = ({
       uiTransform={getShopCardTransform(baseHeight, scale, locked)}
       uiBackground={mobile ? { color: locked ? SHOP_CARD_FILL_LOCKED : SHOP_CARD_FILL } : undefined}
     >
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width, height }}>
-          <UiEntity
-            uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width, height: SHOP_MOBILE_FRAME_THICKNESS }}
-            uiBackground={{ color: frameColor }}
-          />
-          <UiEntity
-            uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 }, width, height: SHOP_MOBILE_FRAME_THICKNESS }}
-            uiBackground={{ color: frameColor }}
-          />
-          <UiEntity
-            uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: SHOP_MOBILE_FRAME_THICKNESS, height }}
-            uiBackground={{ color: frameColor }}
-          />
-          <UiEntity
-            uiTransform={{ positionType: 'absolute', position: { right: 0, top: 0 }, width: SHOP_MOBILE_FRAME_THICKNESS, height }}
-            uiBackground={{ color: frameColor }}
-          />
-        </UiEntity>
-      )}
       {children}
     </UiEntity>
   )

--- a/src/ui/StatsPanel.tsx
+++ b/src/ui/StatsPanel.tsx
@@ -52,8 +52,8 @@ const CLOSE_TOP  = 0
 // ─── Warm card palette ────────────────────────────────────────────────────────
 const CARD_BORDER      = { r: 0.82, g: 0.69, b: 0.39, a: 0.95 }
 const CARD_FILL        = { r: 0.95, g: 0.88, b: 0.70, a: 0.55 }
-// Mobile: fully opaque so the dark atlas doesn't bleed through and muddy contrast
-const CARD_FILL_MOBILE = { r: 0.95, g: 0.88, b: 0.70, a: 1.0 }
+// Mobile: dark background so the bright stat colours stand out
+const CARD_FILL_MOBILE = { r: 0.15, g: 0.09, b: 0.03, a: 0.93 }
 const CARD_TEXT_MUTE   = { r: 0.45, g: 0.28, b: 0.10, a: 1 }
 // On a light card the off-white C.textMain is invisible — use this dark version instead
 const CARD_TEXT_DARK   = { r: 0.20, g: 0.11, b: 0.03, a: 1 }
@@ -241,8 +241,11 @@ const TabBar = ({ hasUnclaimedReward }: { hasUnclaimedReward: boolean }) => {
 const PageNav = ({
   page, lastPage, onPrev, onNext,
 }: { page: number; lastPage: number; onPrev: () => void; onNext: () => void }) => {
+  const mob     = isMobile()
   const canPrev = page > 0
   const canNext = page < lastPage
+  const disabledColor = mob ? { r: 1, g: 1, b: 1, a: 0.35 } : CARD_TEXT_MUTE
+  const pageColor     = mob ? { r: 1, g: 1, b: 1, a: 0.80 } : CARD_TEXT_MUTE
   return (
     <UiEntity
       uiTransform={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', width: '100%', height: 50, flexShrink: 0 }}
@@ -252,15 +255,15 @@ const PageNav = ({
         uiBackground={{ color: canPrev ? BTN_ON : BTN_OFF }}
         onMouseDown={canPrev ? () => { playSound('buttonclick'); onPrev() } : undefined}
       >
-        <Label value="< Prev" fontSize={20} color={canPrev ? BTN_TEXT : CARD_TEXT_MUTE} textAlign="middle-center" />
+        <Label value="< Prev" fontSize={20} color={canPrev ? BTN_TEXT : disabledColor} textAlign="middle-center" />
       </UiEntity>
-      <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={20} color={CARD_TEXT_MUTE} textAlign="middle-center" uiTransform={{ width: 80, height: 40 }} />
+      <Label value={`${page + 1} / ${lastPage + 1}`} fontSize={20} color={pageColor} textAlign="middle-center" uiTransform={{ width: 80, height: 40 }} />
       <UiEntity
         uiTransform={{ width: 110, height: 40, alignItems: 'center', justifyContent: 'center', borderRadius: 10, margin: { left: 20 } }}
         uiBackground={{ color: canNext ? BTN_ON : BTN_OFF }}
         onMouseDown={canNext ? () => { playSound('buttonclick'); onNext() } : undefined}
       >
-        <Label value="Next >" fontSize={20} color={canNext ? BTN_TEXT : CARD_TEXT_MUTE} textAlign="middle-center" />
+        <Label value="Next >" fontSize={20} color={canNext ? BTN_TEXT : disabledColor} textAlign="middle-center" />
       </UiEntity>
     </UiEntity>
   )
@@ -338,16 +341,8 @@ const StatsTab = () => {
               }}
               uiBackground={{ color: mobile ? CARD_FILL_MOBILE : CARD_FILL }}
             >
-              {mobile && (
-                <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: cW, height: cH }}>
-                  <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },                       width: cW,               height: FRAME_THICKNESS }} uiBackground={{ color: CARD_BORDER }} />
-                  <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 },                    width: cW,               height: FRAME_THICKNESS }} uiBackground={{ color: CARD_BORDER }} />
-                  <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },                       width: FRAME_THICKNESS,  height: cH }}              uiBackground={{ color: CARD_BORDER }} />
-                  <UiEntity uiTransform={{ positionType: 'absolute', position: { left: cW - FRAME_THICKNESS, top: 0 },    width: FRAME_THICKNESS,  height: cH }}              uiBackground={{ color: CARD_BORDER }} />
-                </UiEntity>
-              )}
               <Label value={`${val}`} fontSize={30} color={s.color} />
-              <Label value={s.label} fontSize={17} color={mobile ? CARD_TEXT_DARK : CARD_TEXT_MUTE} uiTransform={{ margin: { top: 4 } }} />
+              <Label value={s.label} fontSize={17} color={mobile ? { r: 1, g: 1, b: 1, a: 0.80 } : CARD_TEXT_MUTE} uiTransform={{ margin: { top: 4 } }} />
             </UiEntity>
           )
         })}
@@ -378,9 +373,8 @@ const RewardCard = ({ reward: r }: RewardCardProps) => {
            : mobile    ? CARD_FILL_MOBILE
            :             CARD_FILL
 
-  // On a light (unclaimed) card, C.textMain (off-white) is invisible — use dark text instead
   const isLightCard = !claimed && !claimable
-  const descColor   = mobile && isLightCard ? CARD_TEXT_DARK : (unlocked ? C.textMain : CARD_TEXT_MUTE)
+  const descColor   = mobile ? C.textMain : (isLightCard ? CARD_TEXT_DARK : (unlocked ? C.textMain : CARD_TEXT_MUTE))
 
   const borderColor = claimable ? { r: 0.82, g: 0.69, b: 0.20, a: 0.95 } : CARD_BORDER
 
@@ -410,23 +404,14 @@ const RewardCard = ({ reward: r }: RewardCardProps) => {
         setTimeout(() => claimReward(r.level), 290)
       } : undefined}
     >
-      {/* Mobile border strips — DCL doesn't render borderWidth reliably on mobile */}
-      {mobile && (
-        <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 }, width: w, height: h }}>
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },                   width: w,                height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, bottom: 0 },                width: w,                height: FRAME_THICKNESS }} uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: 0, top: 0 },                   width: FRAME_THICKNESS,  height: h }}               uiBackground={{ color: borderColor }} />
-          <UiEntity uiTransform={{ positionType: 'absolute', position: { left: w - FRAME_THICKNESS, top: 0 }, width: FRAME_THICKNESS,  height: h }}               uiBackground={{ color: borderColor }} />
-        </UiEntity>
-      )}
-      <Label value={`Lv ${r.level}`} fontSize={18} color={claimable ? C.gold : claimed ? C.green : CARD_TEXT_MUTE} />
+      <Label value={`Lv ${r.level}`} fontSize={18} color={claimable ? C.gold : claimed ? C.green : (mobile ? C.textMain : CARD_TEXT_MUTE)} />
       <Label value={r.label} fontSize={15} color={descColor} textAlign="middle-center" uiTransform={{ margin: { top: 3 } }} />
       {isUnlocker && (
-        <Label value={`Unlocks ${cropDef!.name}`} fontSize={13} color={claimed ? C.green : claimable ? C.gold : CARD_TEXT_MUTE} textAlign="middle-center" uiTransform={{ margin: { top: 2 } }} />
+        <Label value={`Unlocks ${cropDef!.name}`} fontSize={13} color={claimed ? C.green : claimable ? C.gold : (mobile ? C.textMain : CARD_TEXT_MUTE)} textAlign="middle-center" uiTransform={{ margin: { top: 2 } }} />
       )}
       {claimed   && <Label value="Claimed" fontSize={14} color={C.green} uiTransform={{ margin: { top: 3 } }} />}
       {claimable && <Label value="Tap!" fontSize={14} color={C.gold}  uiTransform={{ margin: { top: 3 } }} />}
-      {!unlocked && <Label value={`Lv ${r.level}`} fontSize={13} color={CARD_TEXT_MUTE} uiTransform={{ margin: { top: 3 } }} />}
+      {!unlocked && <Label value={`Lv ${r.level}`} fontSize={13} color={mobile ? C.textMain : CARD_TEXT_MUTE} uiTransform={{ margin: { top: 3 } }} />}
     </UiEntity>
   )
 }

--- a/src/ui/TopHud.tsx
+++ b/src/ui/TopHud.tsx
@@ -482,15 +482,25 @@ export const TopHud = () => {
               }}
             >
               <UiEntity uiTransform={{ width: s(214), height: s(34), justifyContent: 'center' }}>
-                <OutlinedLabel
-                  value={isMaxLvl ? 'MAX XP' : `${xp.current} / ${xp.needed} XP`}
-                  fontSize={s(20)}
-                  width={s(214)}
-                  height={s(30)}
-                  color={HUD_WHITE}
-                  outlineColor={HUD_BROWN_DARK}
-                  textAlign="middle-left"
-                />
+                {isMobile() ? (
+                  <Label
+                    value={isMaxLvl ? 'MAX XP' : `${xp.current} / ${xp.needed} XP`}
+                    fontSize={s(20)}
+                    color={HUD_WHITE}
+                    textAlign="middle-left"
+                    uiTransform={{ width: s(214), height: s(30) }}
+                  />
+                ) : (
+                  <OutlinedLabel
+                    value={isMaxLvl ? 'MAX XP' : `${xp.current} / ${xp.needed} XP`}
+                    fontSize={s(20)}
+                    width={s(214)}
+                    height={s(30)}
+                    color={HUD_WHITE}
+                    outlineColor={HUD_BROWN_DARK}
+                    textAlign="middle-left"
+                  />
+                )}
               </UiEntity>
 
               {SHOW_SERVER_INDICATOR && isConnected && (

--- a/ui-preview.tsx
+++ b/ui-preview.tsx
@@ -1,0 +1,366 @@
+// Preview-only panels for `npm run ui-preview`. This file is not part of the deployed scene.
+import { setupUi } from './src/ui'
+import { playerState } from './src/game/gameState'
+import { CropType } from './src/data/cropData'
+import { FertilizerType } from './src/data/fertilizerData'
+import { npcDialogState } from './src/game/npcDialogState'
+import { questProgressMap } from './src/game/questState'
+import { lbState } from './src/ui/LeaderboardPanel'
+import type { FarmSlot, LeaderboardEntry } from './src/shared/farmMessages'
+
+setupUi()
+
+const NOW = Date.parse('2026-06-23T12:00:00Z')
+
+const FARM_SLOTS: FarmSlot[] = [
+  { slotId: 0, wallet: '0x1234567890abcdef1234567890abcdef12345678', displayName: 'Agu', claimedAt: NOW - 18 * 86400000 },
+  { slotId: 1, wallet: '0x9c8f7e6d5c4b3a29181716151413121110ffeedd', displayName: 'Luna', claimedAt: NOW - 9 * 86400000 },
+  { slotId: 2, wallet: '', displayName: '', claimedAt: 0 },
+  { slotId: 3, wallet: '0x1111111111111111111111111111111111111111', displayName: 'Marco', claimedAt: NOW - 30 * 86400000 },
+  { slotId: 4, wallet: '', displayName: '', claimedAt: 0 },
+  { slotId: 5, wallet: '0x2222222222222222222222222222222222222222', displayName: 'Rosa', claimedAt: NOW - 5 * 86400000 },
+  { slotId: 6, wallet: '0x3333333333333333333333333333333333333333', displayName: 'Gerald', claimedAt: NOW - 14 * 86400000 },
+  { slotId: 7, wallet: '', displayName: '', claimedAt: 0 },
+]
+
+const FULL_FARM_SLOTS: FarmSlot[] = FARM_SLOTS.map((slot, index) =>
+  slot.wallet
+    ? slot
+    : {
+        slotId: slot.slotId,
+        wallet: `0x${String(index + 4).repeat(40).slice(0, 40)}`,
+        displayName: `Farmer ${index + 1}`,
+        claimedAt: NOW - (index + 2) * 86400000,
+      }
+)
+
+const LEADERBOARD_ENTRIES: LeaderboardEntry[] = [
+  { rank: 1, address: '0x1111111111111111111111111111111111111111', displayName: 'Marco', beautyScore: 980 },
+  { rank: 2, address: '0x1234567890abcdef1234567890abcdef12345678', displayName: 'Agu', beautyScore: 910 },
+  { rank: 3, address: '0x2222222222222222222222222222222222222222', displayName: 'Rosa', beautyScore: 860 },
+  { rank: 4, address: '0x3333333333333333333333333333333333333333', displayName: 'Gerald', beautyScore: 820 },
+]
+
+function setMap<K, V>(target: Map<K, V>, entries: [K, V][]) {
+  target.clear()
+  for (const [key, value] of entries) {
+    target.set(key, value)
+  }
+}
+
+function resetQuestPreview() {
+  for (const progress of questProgressMap.values()) {
+    progress.current = 0
+    progress.status = progress.id === 'mayorchen_fertilizer' ? 'completed' : 'available'
+  }
+
+  const rosa = questProgressMap.get('rosa')
+  if (rosa) {
+    rosa.current = 3
+    rosa.status = 'active'
+  }
+
+  const marco = questProgressMap.get('marco')
+  if (marco) {
+    marco.current = 10
+    marco.status = 'claimable'
+  }
+
+  const mayor = questProgressMap.get('mayorchen')
+  if (mayor) {
+    mayor.current = 5
+    mayor.status = 'completed'
+  }
+}
+
+function resetNpcDialog() {
+  npcDialogState.npcName = ''
+  npcDialogState.npcId = ''
+  npcDialogState.npcHeadImage = ''
+  npcDialogState.dialogLine = ''
+  npcDialogState.mode = 'greeting'
+  npcDialogState.tutorialPages = []
+  npcDialogState.tutorialPage = 0
+  npcDialogState.tutorialFinalButtonLabel = 'Got it!'
+  npcDialogState.tutorialButtonLabel = 'Got it!'
+  npcDialogState.onClose = null
+  npcDialogState.onAccept = null
+  npcDialogState.onClaim = null
+}
+
+function resetLeaderboardPreview() {
+  lbState.entries = LEADERBOARD_ENTRIES
+  lbState.currentRank = 2
+  lbState.currentScore = 910
+  lbState.loading = false
+  lbState.loaded = true
+}
+
+function resetPreviewState() {
+  playerState.coins = 1240
+  playerState.activeMenu = 'none'
+  playerState.activePlotEntity = null
+  playerState.cropsUnlocked = true
+  playerState.expansion1Unlocked = true
+  playerState.expansion2Unlocked = false
+  playerState.farmerHired = true
+  playerState.workerOutstandingWages = 90
+  playerState.workerUnpaidDays = 2
+  playerState.workerLastWageProcessedAt = NOW - 2 * 86400000
+  playerState.xp = 840
+  playerState.level = 6
+  playerState.wallet = '0x1234567890abcdef1234567890abcdef12345678'
+  playerState.userId = 'preview-user'
+  playerState.avatarUrl = ''
+  playerState.displayName = 'Agustin'
+  playerState.dogOwned = true
+  playerState.totalCropsHarvested = 124
+  playerState.totalWaterCount = 88
+  playerState.totalSeedPlanted = 133
+  playerState.totalSellCount = 39
+  playerState.totalCoinsEarned = 3240
+  playerState.claimedRewards = [2, 4]
+  playerState.beautyScore = 910
+  playerState.beautySlots = [1, 4, 9]
+  playerState.totalLikesReceived = 17
+  playerState.mailbox = [
+    {
+      id: 'mail-1',
+      type: 'coins',
+      reason: 'like',
+      amount: 25,
+      cropType: -1,
+      fromAddress: '0x2222222222222222222222222222222222222222',
+      fromName: 'Rosa',
+      createdAt: NOW - 7200000,
+    },
+    {
+      id: 'mail-2',
+      type: 'seeds',
+      reason: 'visit_water',
+      amount: 3,
+      cropType: CropType.Tomato,
+      fromAddress: '0x3333333333333333333333333333333333333333',
+      fromName: 'Gerald',
+      createdAt: NOW - 3600000,
+    },
+  ]
+  playerState.mailboxSeenCount = 0
+  playerState.serverConnected = true
+  playerState.mySlotId = 0
+  playerState.farmSlots = FARM_SLOTS.map((slot) => ({ ...slot }))
+  playerState.socialToastText = ''
+  playerState.socialToastExpiresAt = 0
+  playerState.levelUpToastText = ''
+  playerState.levelUpToastExpiresAt = 0
+  playerState.viewingFarm = null
+  playerState.organicWaste = 6
+  playerState.compostWasteCount = 4
+  playerState.compostLastCollectedAt = NOW - 20 * 60000
+  playerState.chickenCoopOwned = true
+  playerState.chickens = [
+    { id: 'hen-1', lastEggAt: NOW - 3600000 },
+    { id: 'hen-2', lastEggAt: NOW - 1800000 },
+  ]
+  playerState.chickenFoodInBowl = 9
+  playerState.chickenCoopDirtyAt = NOW - 600000
+  playerState.pigPenOwned = true
+  playerState.pigs = [
+    {
+      id: 'pig-1',
+      purchasedAt: NOW - 12 * 86400000,
+      bornAt: 0,
+      becameAdultAt: NOW - 10 * 86400000,
+      feedScore: 0.72,
+      lastBreedAt: NOW - 4 * 86400000,
+      lastManureAt: NOW - 5400000,
+    },
+  ]
+  playerState.pigFoodInBowl = 6
+  playerState.pigPenDirtyAt = NOW - 900000
+  playerState.grainCount = 11
+  playerState.veggieScrapCount = 8
+  playerState.eggsCount = 5
+  playerState.pigMeatCount = 2
+  playerState.compostBinUnlocked = true
+  playerState.coopDirtAccumMs = 0
+  playerState.penDirtAccumMs = 0
+  playerState.activeFeedBowl = null
+  playerState.rotSystemUnlocked = true
+  playerState.progressionEventStep = 'complete'
+  playerState.chickenTutorialStep = 'done'
+  playerState.pigTutorialStep = 'done'
+  playerState.lastNpcVisitAt = NOW - 86400000
+  playerState.npcScheduleIndex = 2
+  playerState.viewingFarmDisplayName = ''
+  playerState.visitorSessionWaterCount = 2
+  playerState.tutorialCompostCycle = false
+  playerState.unlockedPlotGroups = ['north-field']
+  playerState.activePlotGroupName = 'north-field'
+  playerState.farmAssignmentOverlayActive = false
+  playerState.farmAssignmentOverlaySlotId = -1
+  playerState.farmAssignmentOverlayStartedAt = 0
+  playerState.farmAssignmentOverlayDurationMs = 0
+  playerState.farmGameplayUiReady = true
+  playerState.menuInputLockDisabled = false
+  playerState.plazaMapMinimized = false
+  playerState.freeSlotNotification = null
+
+  setMap(playerState.seeds, [
+    [CropType.Onion, 12],
+    [CropType.Potato, 9],
+    [CropType.Garlic, 6],
+    [CropType.Tomato, 5],
+    [CropType.Carrot, 3],
+  ])
+
+  setMap(playerState.harvested, [
+    [CropType.Onion, 18],
+    [CropType.Potato, 14],
+    [CropType.Garlic, 11],
+    [CropType.Tomato, 7],
+    [CropType.Carrot, 4],
+    [CropType.Corn, 2],
+  ])
+
+  playerState.unlockedCrops = new Set([
+    CropType.Onion,
+    CropType.Potato,
+    CropType.Garlic,
+    CropType.Tomato,
+    CropType.Carrot,
+    CropType.Corn,
+  ])
+
+  setMap(playerState.farmerSeeds, [
+    [CropType.Onion, 8],
+    [CropType.Tomato, 4],
+  ])
+
+  setMap(playerState.farmerInventory, [
+    [CropType.Onion, 7],
+    [CropType.Potato, 5],
+  ])
+
+  setMap(playerState.fertilizers, [
+    [FertilizerType.GrowthBoost, 4],
+    [FertilizerType.YieldBoost, 1],
+  ])
+
+  resetQuestPreview()
+  resetNpcDialog()
+  resetLeaderboardPreview()
+}
+
+function ownFarmUi() {
+  resetPreviewState()
+}
+
+function waitingForSlotUi() {
+  resetPreviewState()
+  playerState.farmGameplayUiReady = false
+  playerState.mySlotId = -1
+  playerState.wallet = ''
+  playerState.displayName = ''
+  playerState.farmSlots = FULL_FARM_SLOTS.map((slot) => ({ ...slot }))
+  playerState.plazaMapMinimized = false
+}
+
+function farmMapUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'farmSelect'
+  playerState.plazaMapMinimized = false
+}
+
+function plantMenuUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'plant'
+}
+
+function shopMenuUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'shop'
+}
+
+function inventoryUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'inventory'
+}
+
+function statsUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'stats'
+}
+
+function questsUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'quests'
+}
+
+function farmPanelUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'farm'
+}
+
+function chickenCoopUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'chickenCoop'
+}
+
+function pigPenUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'pigPen'
+}
+
+function feedChickensUi() {
+  resetPreviewState()
+  playerState.activeFeedBowl = 'chicken'
+  playerState.activeMenu = 'feedBowl'
+}
+
+function npcQuestUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'npcDialog'
+  npcDialogState.npcName = 'Rosa'
+  npcDialogState.npcId = 'rosa'
+  npcDialogState.npcHeadImage = 'assets/images/npcs/rosa.png'
+  npcDialogState.dialogLine = "Could you harvest 5 onions for me, dear?\nI'm making soup for the whole plaza."
+  npcDialogState.mode = 'quest_offer'
+  npcDialogState.onAccept = () => {}
+  const rosa = questProgressMap.get('rosa')
+  if (rosa) {
+    rosa.current = 3
+    rosa.status = 'available'
+  }
+}
+
+function leaderboardUi() {
+  resetPreviewState()
+  playerState.activeMenu = 'leaderboard'
+}
+
+function visitorHudUi() {
+  resetPreviewState()
+  playerState.viewingFarm = '0x2222222222222222222222222222222222222222'
+  playerState.viewingFarmDisplayName = 'Rosa'
+  playerState.farmGameplayUiReady = false
+  playerState.activeMenu = 'none'
+}
+
+export default {
+  'Own farm HUD': ownFarmUi,
+  'Waiting for slot': waitingForSlotUi,
+  'Farm map': farmMapUi,
+  'Plant menu': plantMenuUi,
+  Shop: shopMenuUi,
+  Inventory: inventoryUi,
+  Stats: statsUi,
+  Quests: questsUi,
+  'Farm panel': farmPanelUi,
+  'Chicken coop': chickenCoopUi,
+  'Pig pen': pigPenUi,
+  'Feed chickens': feedChickensUi,
+  'NPC quest offer': npcQuestUi,
+  Leaderboard: leaderboardUi,
+  'Visitor HUD': visitorHudUi,
+}


### PR DESCRIPTION
## Mobile UI Pass + Farm Timing Bug Fix

### Mobile UI Improvements

All changes in this section are **mobile-only** and use `isMobile()` guards — desktop layout is unchanged.

#### Farm Panel (`FarmPanel.tsx`)
- Enlarged plot cards (305×400px), icons (150px), padding, and progress bars for mobile
- Tab bar buttons scaled up (240×60px) with white text (active and inactive)
- 3 cards per page on mobile (vs 8 on desktop)
- Plot area uses an explicit calculated height (`MOB_PLOT_AREA_H`) so absolute-positioned children can anchor reliably from the bottom — `flex: 1` is unreliable for this in DCL's Yoga implementation
- Cards centered vertically between the tab bar and pagination buttons
- Pagination pinned at the bottom of the panel with large buttons (200×64px) and white text
- Compost tab on mobile: dark card background, white text throughout, centered buttons
- Compost "not unlocked" message: removed the brown card background — plain white text only

#### Inventory Panel (`InventoryPanel.tsx`)
- Tab bar scaled up on mobile, label text white
- All item name and count labels use white on mobile (minimum `ss(26)` font size)

#### Plant Menu (`PlantMenu.tsx`)
- Seed card labels (crop name, count) minimum `ss(26)` on mobile
- Header text and empty-state text scaled up on mobile

#### Quest Panel (`QuestPanel.tsx`)
Complete rewrite of the quest list UI:
- **Collapsed by default**: each quest shows a single row — NPC avatar, title, and current status (`3 / 10`, `Ready to claim!`, etc.)
- **Tap to expand**: shows progress bar, reward coins/XP, or full milestone checklist
- **2-column checklist layout on mobile**: milestone steps split into left/right columns, using the available horizontal space and keeping `ss(26)` minimum font size without requiring vertical scroll
- **Pagination**: 4 items per page with Prev/Next buttons matching Farm Panel style (200×64px, white text)
- `overflow: scroll` on the page list in case multiple items are expanded simultaneously
- **Debug mode** (`QUEST_DEBUG = true` in `QuestPanel.tsx`): forces all 4 tutorial milestone cards + all 7 NPC quests visible at once (11 items across 3 pages) — **set to `false` before shipping**

#### Stats Panel (`StatsPanel.tsx`)
- Stats cards: dark fill on mobile so colored stat values stand out
- Rewards tab: all label text white on mobile (level badge, description, unlock label, locked level hint)
- `PageNav` (used by both Rewards and Leaderboard): disabled button text white at 35% opacity, page indicator white at 80% opacity on mobile

#### Main UI (`ui.tsx`)
- `BottomNav` (Farm / Inventory / Quests buttons) is now hidden while `PlantMenu` is open to avoid overlap

---

### Bug Fixes

#### Farm Panel — growth timer mismatch (`FarmPanel.tsx`)
The UI panel was showing a different countdown than the 3D world timer. Root cause: the panel used `def.growTimeMs` (the crop's base grow time) while `growthSystem.ts` computes an `effectiveGrowTimeMs` that accounts for two modifiers:
- **Tutorial mode**: Onion grows in 30s instead of its normal duration
- **GrowthBoost fertilizer**: reduces grow time by 25%

Additionally, `getWateringStatus` calculates watering window boundaries using `def.growTimeMs`, which could return a `nextWindowInMs` value that falls *after* the crop's actual finish time — causing the panel to display `"Water in 1m 30s"` when the crop would be ready in 30s.

**Fix**: compute `effectiveGrowTimeMs` in `PlotTile` mirroring `growthSystem.ts`, use it for the progress bar and countdown, and suppress `"Water in X"` when the next window opens after `effectiveGrowTimeMs - elapsed`.

#### 3D Timer Text — removed outline (`actions.ts`)
Removed the black outline (`outlineWidth: 0.15`) from the billboard timer text rendered above soil plots.

Closes #147 
Closes #148
Closes #149 
Closes #151 
