### PR TITLE
fix: remove wrong close button at sell crops ui

### DIFF
--- a/src/ui/SellMenu.tsx
+++ b/src/ui/SellMenu.tsx
@@ -95,7 +95,7 @@ const SellPanelFrame = ({ onClose, children }: { onClose: () => void; children?:
             width: mob ? CLOSE_SIZE_M : CLOSE_SIZE,
             height: mob ? CLOSE_SIZE_M : CLOSE_SIZE,
           }}
-          uiBackground={{ texture: { src: CLOSE_BTN_IMG, wrapMode: 'clamp' }, textureMode: 'stretch' }}
+          uiBackground={mob ? { texture: { src: CLOSE_BTN_IMG, wrapMode: 'clamp' }, textureMode: 'stretch' } : undefined}
           onMouseDown={() => { playSound('buttonclick'); onClose() }}
         />
       </UiEntity>


### PR DESCRIPTION
Fix duplicate close button on desktop in Sell menu

SellMenu's close button always rendered the closebutton.png overlay, unlike every other panel (FarmPanel, ShopMenu, PlantMenu, StatsPanel, etc.) which only show that texture on mobile and rely on an invisible hotspot on desktop (the panel's own atlas already has the close X baked in). This left a duplicate close icon stuck on top of the Sell panel in desktop. Made the uiBackground conditional on isMobile() to match the rest of the UI.

Closes #159 
