### PR TITLE
fix: split end-of-tutorial Mayor dialog into multiple pages

### DIFF
--- a/src/systems/tutorialSystem.ts
+++ b/src/systems/tutorialSystem.ts
@@ -157,7 +157,11 @@ function goToTalkMayor() {
     setArrowTarget(null)   // tutorial done — hide arrow
     // Mayor is already walking away (departure was triggered by closeDialog)
     showTutorialDialog(
-      "You've done it — you're a true farmer now! 🌱\n\nI've unlocked three more soil plots for you. Also, head to your shop computer — Onion, Potato and Garlic seeds are all available now! Tier 2 & 3 crops unlock later as you grow.\n\nThe town of CozyFarm is proud of you. Good luck!",
+      [
+        "You've done it — you're a true farmer now! 🌱\n\nI've unlocked three more soil plots for you.",
+        "Also, head to your shop computer — Onion, Potato and Garlic seeds are all available now! Tier 2 & 3 crops unlock later as you grow.",
+        "The town of CozyFarm is proud of you. Good luck!",
+      ],
       "Thanks, Mayor!",
       () => {
         // If Mayor is somehow still idle, make sure he departs


### PR DESCRIPTION
## Summary
- The final Mayor Chen dialog (shown after completing the tutorial quest) was a single long string, which overflowed its fixed-height text box and got rendered underneath the "Thanks, Mayor!" button instead of properly clearing it.
- Split the message into 3 shorter pages (paginated via `showTutorialDialog`'s existing array support, same pattern already used elsewhere in `tutorialSystem.ts`), so each page fits within the dialog box on both desktop and mobile.

## Test plan
- [x] `npm run build` type-checks clean
- [x] Verified in Creator Hub preview: dialog now advances through 3 pages ("Next" → "Next" → "Thanks, Mayor!") with no text/button overlap

Closes #177 