### PR TITLE
fix: virtual screens

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,4 +1,6 @@
 import ReactEcs, { ReactEcsRenderer, UiEntity } from '@dcl/sdk/react-ecs'
+import { isMobile } from '@dcl/sdk/platform'
+import { getExplorerInformation } from '~system/Runtime'
 import { playerState } from './game/gameState'
 import { TopHud }        from './ui/TopHud'
 import { BottomNav }     from './ui/BottomNav'
@@ -27,8 +29,20 @@ import { LoadingOverlay }   from './ui/LoadingOverlay'
 import { MAILBOX_FEATURE_ENABLED } from './game/featureFlags'
 import { PROFILE_HUD_DEBUG } from './debug/profileHudDebug'
 
+function applyUiRenderer(): void {
+  ReactEcsRenderer.setUiRenderer(MainUi, {
+    virtualWidth: isMobile() ? 1600 : 1920,
+    virtualHeight: isMobile() ? 720 : 1080
+  })
+}
+
 export function setupUi() {
-  ReactEcsRenderer.setUiRenderer(MainUi, { virtualWidth: 1920, virtualHeight: 1080 })
+  applyUiRenderer()
+  // isMobile() resolves getExplorerInformation() asynchronously, so the first
+  // call above may still report desktop — reapply once the real platform is known.
+  void getExplorerInformation({})
+    .then(() => applyUiRenderer())
+    .catch(() => {})
 }
 
 const MainUi = () => {


### PR DESCRIPTION
## Summary
- Small UI on mobile was caused by `setupUi()` always rendering at a fixed desktop virtual canvas (1920x1080), regardless of platform.
- `isMobile()` resolves asynchronously (via `getExplorerInformation`), so the very first render could still report desktop even on a phone.

## Changes
- `virtualWidth`/`virtualHeight` now scale down to `1600x720` on mobile (vs `1920x1080` on desktop), matching the fix already applied in `dead-surge`.
- Added `applyUiRenderer()` and re-invoke it once `getExplorerInformation()` resolves, so the UI renderer picks up the correct platform even if the first call ran before it was known.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify on mobile device/emulator that HUD and menus render at proper scale
- [ ] Verify desktop layout is unchanged

Closes #181 
