### PR TITLE
Add scene description for world listing

### DIFF
--- a/scene.json
+++ b/scene.json
@@ -3,7 +3,7 @@
   "runtimeVersion": "7",
   "display": {
     "title": "CozyFarm",
-    "description": "Empty Scene Template",
+    "description": "Grow crops, raise animals, and build your dream farm! Claim your own plot, harvest and sell produce, decorate your space, and hang out with friends in this cozy multiplayer farming world.",
     "favicon": "favicon_asset",
     "navmapThumbnail": "assets/scene/Images/CozyFarm.png"
   },

--- a/scene.json
+++ b/scene.json
@@ -3,7 +3,7 @@
   "runtimeVersion": "7",
   "display": {
     "title": "CozyFarm",
-    "description": "Grow crops, raise animals, and build your dream farm! Claim your own plot, harvest and sell produce, decorate your space, and hang out with friends in this cozy multiplayer farming world.",
+    "description": "Grow crops, raise animals, and build your dream farm! Claim your own plot, harvest and sell produce, decorate your space, and enjoy this cozy farming world.",
     "favicon": "favicon_asset",
     "navmapThumbnail": "assets/scene/Images/CozyFarm.png"
   },


### PR DESCRIPTION
## Description
Adds a player-facing scene description to `scene.json` (`display.description`), replacing the default "Empty Scene Template" placeholder. This was flagged by Kim Currier (marketing) as missing on the world listing/discovery page.

Closes #184

Requested by Agustin Carriso via Slack