### PR TITLE
fix: mobile ui virtual screens and house glb

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,6 +1,4 @@
 import ReactEcs, { ReactEcsRenderer, UiEntity } from '@dcl/sdk/react-ecs'
-import { isMobile } from '@dcl/sdk/platform'
-import { getExplorerInformation } from '~system/Runtime'
 import { playerState } from './game/gameState'
 import { TopHud } from './ui/TopHud'
 import { BottomNav } from './ui/BottomNav'
@@ -28,18 +26,8 @@ import { VisitHud } from './ui/VisitHud'
 import { LoadingOverlay } from './ui/LoadingOverlay'
 import { MAILBOX_FEATURE_ENABLED } from './game/featureFlags'
 
-function applyUiRenderer(): void {
-  ReactEcsRenderer.setUiRenderer(MainUi, {
-    virtualWidth: isMobile() ? 1600 : 1920,
-    virtualHeight: isMobile() ? 720 : 1080,
-  })
-}
-
 export function setupUi() {
-  applyUiRenderer()
-  void getExplorerInformation({})
-    .then(() => applyUiRenderer())
-    .catch(() => {})
+  ReactEcsRenderer.setUiRenderer(MainUi, { virtualWidth: 1920, virtualHeight: 1080 })
 }
 
 const MainUi = () => {


### PR DESCRIPTION
## Summary
- Fix mobile UI scaling: the UI renderer used a smaller virtual canvas (1600x720) on mobile vs desktop (1920x1080), which made every fixed-size UI element render proportionally larger on mobile screens. Now both platforms use a fixed 1920x1080 virtual canvas.
- Update the Farm01 house model to add the windows that were missing from the previous version.

## Test plan
- [ ] Load the scene on mobile and confirm UI panels render at the correct size
- [ ] Load the scene on desktop and confirm no regression
- [ ] Check the Farm01 house in-world and confirm the windows are present

Closes #191 
Closes #190 