### PR TITLE
fix: pointer hover tooltip stuck for up to 60s on short-grow crops).

### DIFF
--- a/src/systems/growthSystem.ts
+++ b/src/systems/growthSystem.ts
@@ -155,12 +155,14 @@ function growthSystem(_dt: number) {
     // Update timer text every frame (cheap — just updates TextShape content)
     setSoilTimerText(entity, formatTime(effectiveGrowTimeMs - elapsed))
 
-    // Refresh hover text when canWater changes, or on a timer based on remaining time
-    // (sub-minute: every second so the countdown feels live; otherwise every 60s)
+    // Refresh hover text when canWater changes, or on a timer based on remaining time.
+    // formatTime() only shows "Xh Ym" once an hour+ remains (changes once a minute),
+    // but drops to "Xm Ys"/"Xs" under an hour (changes every second) — match that
+    // exactly so short-grow crops (e.g. Onion, 2 min) never show a stale value.
     const wasCanWater = prevCanWater.get(entity)
     const lastUpdate = lastHoverUpdateAt.get(entity) ?? 0
     const remaining = effectiveGrowTimeMs - elapsed
-    const updateInterval = remaining < 60_000 ? 1_000 : 60_000
+    const updateInterval = remaining >= 3_600_000 ? 60_000 : 1_000
     if (wasCanWater !== canWater || now - lastUpdate > updateInterval) {
       prevCanWater.set(entity, canWater)
       lastHoverUpdateAt.set(entity, now)


### PR DESCRIPTION
## Summary
Fixes #172. The pointer hover tooltip on soil plots refreshed on a hardcoded 60s
timer whenever more than a minute of grow time remained, while the in-world
floating timer above the soil recalculated every frame. On short-grow crops
(Onion is 2 min — the tutorial's first crop) this made the tooltip look frozen
at "2m 0s" for up to a full minute while the floating timer kept ticking down
normally, which is exactly the desync Gino reported.

## Root cause
`src/systems/growthSystem.ts` picked the hover-text refresh interval from a
fixed `remaining < 60_000` check, unrelated to what `formatTime()` actually
displays:
- `formatTime()` shows `"Xh Ym"` once an hour+ remains (only changes once a
  minute), but drops to `"Xm Ys"` / `"Xs"` under an hour (changes every second).
- The old threshold refreshed every 60s any time more than a minute remained —
  so for a 2-minute crop, the whole first minute showed a stale value even
  though the format needed second-level precision the entire time.

## Fix
Tie the refresh interval to the same 1-hour boundary `formatTime()` uses, so
the tooltip only refreshes as often as the displayed text can actually change:
`remaining >= 3_600_000 ? 60_000 : 1_000`. No extra refreshes for long-grow
crops (Tomato/Carrot/Corn/Lavender still spend most of their time on the 60s
cadence) — only short-grow crops (Onion/Potato/Garlic) get per-second updates,
which is what they needed all along.

## Test plan
- [x] `npm run build` (type-check + bundle) passes
- [ ] `npm run start`, plant an Onion, water it, hover the plot with the
      reticle, and confirm the tooltip countdown ticks down every second in
      lockstep with the floating 3D timer (no more stuck-at-2:00 tooltip)

Closes #172 