### PR TITLE
ft: preload UI assets

### DIFF
--- a/src/data/uiPreloadAssets.ts
+++ b/src/data/uiPreloadAssets.ts
@@ -1,0 +1,69 @@
+import {
+  CROP_SEED_IMAGES,
+  CROP_HARVEST_IMAGES,
+  FERTILIZER_ICON_SRCS,
+  COINS_IMAGE,
+  DOG01_ICON,
+  CHICKEN_ICON,
+  EGG_ICON,
+  GRAIN_ICON,
+  PIG_ICON,
+  MANURE_ICON,
+  VEGGIE_SCRAP_ICON,
+  BTN_INVENTORY,
+  BTN_FARM,
+  BTN_QUESTS,
+  BTN_PROFILE,
+  SOIL_ICON,
+  ORGANIC_WASTE_ICON,
+  WATERINGCAN_ICON,
+  WATER_ICON,
+  WATER_DRY_ICON,
+  HAND_ICON,
+  SHOPINGCART_ICON,
+  COINS_ICON,
+  DIALOG_ICON,
+  BOX_CROPS_ICON,
+  EXCLAMATION_ICON,
+  QUESTION_ICON,
+  QUESTION_DONE_ICON,
+} from './imagePaths'
+import { NPC_ROSTER } from './npcData'
+
+// Revamp UI chrome — declared locally because the panels that use them
+// (Shop/Farm/Inventory/Sell/Plant/Fertilize/Mailbox/Feed/AnimalPanel/...)
+// each redeclare the same literal instead of sharing one constant.
+const CARD_IMG                = 'assets/images/revamp/card.png'
+const CARD_LOCKED_IMG         = 'assets/images/revamp/lockedlevel.png'
+const TAB_SELECTED_IMG        = 'assets/images/revamp/selected.png'
+const TAB_IDLE_IMG            = 'assets/images/revamp/notselected.png'
+const MINI_BUTTON_IMG         = 'assets/images/revamp/mini-button.png'
+const MINI_BUTTON_NO_COIN_IMG = 'assets/images/revamp/mini-button-no-coin.png'
+const MINI_BUTTON_NOCOINS_IMG = 'assets/images/revamp/mini-button-not-coins.png'
+const BUTTON_NOTLEVEL_IMG     = 'assets/images/revamp/button-not-level.png'
+const BTN_PRIMARY_IMG         = 'assets/images/revamp/Type=Primary, State=Focused.png'
+const BTN_SECONDARY_IMG       = 'assets/images/revamp/Type=Secondary, State=Default.png'
+const REVAMP_BG_IMG           = 'assets/images/revamp/background.png'
+const REVAMP_NAMES_IMG        = 'assets/images/revamp/names.png'
+const REVAMP_CLOSE_IMG        = 'assets/images/ui_loading/closebutton.png'
+const NPC_DIALOG_BG           = 'assets/images/ui_loading/npc_dialog_background.png'
+const HUD_ATLAS               = 'assets/images/ui_loading/profile_atlas.png'
+const ENVELOPE_ICON           = 'assets/images/envelope.png'
+
+/** Every static texture used by a UI panel (shop, jukebox chrome, dialogs, HUD, etc.), preloaded via AssetLoad so panels don't pop-in on first open. */
+export const UI_PRELOAD_ASSETS: string[] = Array.from(new Set([
+  ...Object.values(CROP_SEED_IMAGES),
+  ...Object.values(CROP_HARVEST_IMAGES),
+  ...Object.values(FERTILIZER_ICON_SRCS),
+  ...NPC_ROSTER.map((npc) => npc.headImage),
+  COINS_IMAGE, DOG01_ICON, CHICKEN_ICON, EGG_ICON, GRAIN_ICON, PIG_ICON, MANURE_ICON, VEGGIE_SCRAP_ICON,
+  BTN_INVENTORY, BTN_FARM, BTN_QUESTS, BTN_PROFILE,
+  SOIL_ICON, ORGANIC_WASTE_ICON, WATERINGCAN_ICON, WATER_ICON, WATER_DRY_ICON, HAND_ICON,
+  SHOPINGCART_ICON, COINS_ICON, DIALOG_ICON, BOX_CROPS_ICON,
+  EXCLAMATION_ICON, QUESTION_ICON, QUESTION_DONE_ICON,
+  CARD_IMG, CARD_LOCKED_IMG, TAB_SELECTED_IMG, TAB_IDLE_IMG,
+  MINI_BUTTON_IMG, MINI_BUTTON_NO_COIN_IMG, MINI_BUTTON_NOCOINS_IMG, BUTTON_NOTLEVEL_IMG,
+  BTN_PRIMARY_IMG, BTN_SECONDARY_IMG,
+  REVAMP_BG_IMG, REVAMP_NAMES_IMG, REVAMP_CLOSE_IMG,
+  NPC_DIALOG_BG, HUD_ATLAS, ENVELOPE_ICON,
+]))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { isServer } from '@dcl/sdk/network'
 import { getUserData } from '~system/UserIdentity'
 import { PlayerIdentityData } from '@dcl/sdk/ecs'
 import { setupUi } from './ui'
+import { preloadUiAssets } from './systems/uiAssetPreloadSystem'
 import { setupEntities, unlockSoilsPhase1, unlockSoilsPhase2, unlockSoilsAll6, getSoilEntities, getComputerEntity, getTruckEntity, initVisitorWaterFeedback, resetSoilPlots, setCompostBinVisible, unlockPlotGroupByName } from './systems/interactionSetup'
 import { setupLandscape } from './systems/landscapeSystem'
 import './systems/growthSystem'
@@ -57,6 +58,7 @@ export function main() {
   SkyboxTime.createOrReplace(engine.RootEntity, { fixedTime: 43200 })
 
   setupUi()
+  preloadUiAssets()
 
   setupEntities()
   setupLandscape()

--- a/src/systems/uiAssetPreloadSystem.ts
+++ b/src/systems/uiAssetPreloadSystem.ts
@@ -1,0 +1,6 @@
+import { AssetLoad, engine } from '@dcl/sdk/ecs'
+import { UI_PRELOAD_ASSETS } from '../data/uiPreloadAssets'
+
+export function preloadUiAssets() {
+  AssetLoad.create(engine.addEntity(), { assets: UI_PRELOAD_ASSETS })
+}


### PR DESCRIPTION
## Preload UI textures via `AssetLoad`

Adds SDK7's `AssetLoad` component so UI assets are prefetched during the loading screen instead of downloading on demand the first time a panel opens (shop, jukebox chrome, NPC dialogs, HUD, etc.), eliminating the pop-in delay on first use.

- `src/data/uiPreloadAssets.ts` — centralized list of every static texture used across UI panels (crop seed/harvest images, fertilizer icons, NPC dialog portraits, HUD/inventory/animal icons, and the shared revamp chrome: cards, tabs, buttons, panel backgrounds, HUD atlas, dialog background, mailbox envelope).
- `src/systems/uiAssetPreloadSystem.ts` — `preloadUiAssets()` creates one entity with `AssetLoad.create(...)` listing those assets, telling the renderer to start caching them in the background. No visible entity, purely a prefetch.
- `src/index.ts` — calls `preloadUiAssets()` right after `setupUi()`, at client boot, so prefetching runs during the loading overlay rather than when a panel is first opened.

Intentionally excluded `ui_loading/background.png` and `atlas.png` (the loading screen's own assets — they render on the same frame the preload kicks off, so preloading buys nothing). Also found `ShopMenu.tsx` references a non-existent `assets/images/ui_loading/shop_atlas.png` via a dead, unused constant (`SHOP_ATLAS`) — left untouched since it's pre-existing and out of scope, but flagging it here in case it's worth a follow-up cleanup.

Closes #195.
