### PR TITLE
fix: quest bugs

### DIFF
--- a/src/game/questState.ts
+++ b/src/game/questState.ts
@@ -230,10 +230,13 @@ export function resetQuestProgress(): void {
   }
 }
 
-/** Unlock the Mayor fertilizer quest after the rot system is enabled. */
+/** Unlock the Mayor fertilizer quest after the rot system is enabled.
+ *  Only migrates the quest out of its hidden default state (current === 0) —
+ *  a genuinely claimed quest also has status 'completed' but current === target,
+ *  so it's left alone instead of being restarted every session. */
 export function unlockFertilizerQuest(): void {
   const qp = questProgressMap.get('mayorchen_fertilizer')
-  if (qp && qp.status === 'completed') {
+  if (qp && qp.status === 'completed' && qp.current === 0) {
     qp.status  = 'active'
     qp.current = 0
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,15 +254,20 @@ export function main() {
       // Dev reset: re-spawn Mayor and restart tutorial from welcome step
       tutorialCallbacks.onResetComplete = () => initNpcSystem(MAYOR_DEF, startRegularNpcRotation)
 
-      if (tutorialState.active) {
-        // Tutorial in progress — spawn Mayor as guide; rotation starts after he departs
-        initNpcSystem(MAYOR_DEF, startRegularNpcRotation)
+      // Checked in this order because initAnimalTutorialSystem() (called above) may
+      // have already spawned Mayor via its own resume/trigger path — if a save ever
+      // ends up with tutorialState.active AND an animal tutorial both mid-flow (e.g.
+      // a player who leveled past 8/12 while ignoring the welcome tutorial dialogs),
+      // that spawn must take priority so this block doesn't spawn a second Mayor.
+      if (animalTutorialState.chickenActive || animalTutorialState.pigActive) {
+        // Animal tutorial in progress — Mayor spawned by initAnimalTutorialSystem (resume path)
+        // Rotation starts when Mayor departs via setOnChickenTutorialComplete / setOnPigTutorialComplete
       } else if (progressionEventState.active) {
         // Progression event in progress — Mayor already spawned by initProgressionEventsSystem
         // Rotation will start when Mayor departs (wired via the onDespawned callback inside that system)
-      } else if (animalTutorialState.chickenActive || animalTutorialState.pigActive) {
-        // Animal tutorial in progress — Mayor spawned by initAnimalTutorialSystem (resume path)
-        // Rotation starts when Mayor departs via setOnChickenTutorialComplete / setOnPigTutorialComplete
+      } else if (tutorialState.active) {
+        // Tutorial in progress — spawn Mayor as guide; rotation starts after he departs
+        initNpcSystem(MAYOR_DEF, startRegularNpcRotation)
       } else {
         startRegularNpcRotation()
       }

--- a/src/services/saveService.ts
+++ b/src/services/saveService.ts
@@ -31,6 +31,7 @@ import { spawnFarmer } from '../systems/farmerSystem'
 import { initBeautySpotSystem } from '../systems/beautySpotSystem'
 import { spawnDog } from '../systems/dogSystem'
 import { animalTutorialState } from '../game/animalTutorialState'
+import { progressionEventState } from '../game/progressionEventState'
 
 // ---------------------------------------------------------------------------
 // Auto-save interval
@@ -279,6 +280,12 @@ function applyPayload(payload: FarmStatePayload): void {
   const pStep = playerState.pigTutorialStep
   animalTutorialState.pigStep   = pStep as any
   animalTutorialState.pigActive = pStep !== '' && pStep !== 'complete'
+
+  // Restore progression event state — was previously never rehydrated, so
+  // progressionEventState.step stayed '' for any returning player who had
+  // already finished it, making the Quest Panel show a fake sample checklist.
+  progressionEventState.step   = playerState.progressionEventStep as any
+  progressionEventState.active = playerState.progressionEventStep !== '' && playerState.progressionEventStep !== 'complete'
 
   playerState.lastNpcVisitAt       = (payload as any).lastNpcVisitAt ?? 0
   playerState.npcScheduleIndex     = (payload as any).npcScheduleIndex ?? 0

--- a/src/systems/animalTutorialSystem.ts
+++ b/src/systems/animalTutorialSystem.ts
@@ -53,6 +53,10 @@ function setChickenStep(step: ChickenTutorialStep): void {
 }
 
 function goToChickenBuyCoop(): void {
+  // Player may already own the coop (e.g. bought it before this tutorial step
+  // ever registered its watch callback) — skip ahead instead of waiting on a
+  // purchase event that will never fire again.
+  if (playerState.chickenCoopOwned) { goToChickenBuyChicken(); return }
   setChickenStep('buy_coop')
 
   const coopEntity = getCoopAreaEntity()
@@ -79,6 +83,10 @@ function goToChickenBuyCoop(): void {
 }
 
 function goToChickenBuyChicken(): void {
+  // Player may already own chickens (up to the 5-per-coop cap) — the watch
+  // callback only fires on the 0→1 transition, so if they're already past
+  // that point (or capped out) it can never fire again. Skip ahead.
+  if (playerState.chickens.length > 0) { goToChickenFeed(); return }
   setChickenStep('buy_chicken')
 
   const computer = engine.getEntityOrNullByName('Computer.glb')
@@ -98,6 +106,8 @@ function goToChickenBuyChicken(): void {
 }
 
 function goToChickenFeed(): void {
+  // Bowl may already have food in it — same "already satisfied" guard.
+  if (playerState.chickenFoodInBowl > 0) { goToChickenCleanIntro(); return }
   setChickenStep('feed_chicken')
 
   const foodEntity = getCoopFoodEntity()
@@ -194,6 +204,11 @@ function resumeChickenTutorial(onComplete: () => void): void {
   onChickenTutorialCompleteCb      = onComplete
   animalTutorialState.chickenActive = true
 
+  // Same guard as triggerChickenTutorial — without it, any NPC left over from
+  // another code path (e.g. the regular quest rotation) sits alongside the
+  // freshly spawned Mayor instead of being evicted first.
+  departAllActiveNpcs()
+
   initNpcSystem(MAYOR_DEF, () => {
     animalTutorialState.chickenActive = false
     onComplete()
@@ -223,6 +238,8 @@ function setPigStep(step: PigTutorialStep): void {
 }
 
 function goToPigBuyPen(): void {
+  // Same "already satisfied" guard as the chicken coop step.
+  if (playerState.pigPenOwned) { goToPigBuyPig(); return }
   setPigStep('buy_pen')
 
   const penEntity = getPenAreaEntity()
@@ -247,6 +264,10 @@ function goToPigBuyPen(): void {
 }
 
 function goToPigBuyPig(): void {
+  // Same "already satisfied" guard as the chicken step — the watch callback
+  // only fires on the 0→1 transition, so a player already past it (or capped
+  // out at 5 pigs) would otherwise be stuck here forever.
+  if (playerState.pigs.length > 0) { goToPigFeed(); return }
   setPigStep('buy_pig')
 
   const computer = engine.getEntityOrNullByName('Computer.glb')
@@ -269,6 +290,7 @@ function goToPigBuyPig(): void {
 }
 
 function goToPigFeed(): void {
+  if (playerState.pigFoodInBowl > 0) { goToPigCleanIntro(); return }
   setPigStep('feed_pig')
 
   const foodEntity = getPenFoodEntity()
@@ -414,6 +436,8 @@ function triggerPigTutorial(onComplete: () => void): void {
 function resumePigTutorial(onComplete: () => void): void {
   onPigTutorialCompleteCb      = onComplete
   animalTutorialState.pigActive = true
+
+  departAllActiveNpcs()
 
   initNpcSystem(MAYOR_DEF, () => {
     animalTutorialState.pigActive = false

--- a/src/systems/progressionEventsSystem.ts
+++ b/src/systems/progressionEventsSystem.ts
@@ -324,6 +324,8 @@ function resumeProgressionEvent(): void {
   progressionEventState.active = true
   const step = playerState.progressionEventStep as ProgressionEventStep
 
+  departAllActiveNpcs()
+
   initNpcSystem(MAYOR_DEF, () => {
     progressionEventState.active = false
     onEventCompleteCb?.()

--- a/src/ui/QuestPanel.tsx
+++ b/src/ui/QuestPanel.tsx
@@ -160,17 +160,14 @@ function buildGuideItems(): GuideItem[] {
     ? TUTORIAL_MILESTONES.map((m) => ({ label: m.label, status: getTutorialMilestoneStatus(m) }))
     : buildSampleChecklist(TUTORIAL_MILESTONES.map((m) => m.label), 4)
 
-  const progressionEntries = progressionEventState.active
-    ? PROGRESSION_MILESTONES.map((m) => ({ label: m.label, status: getProgressionMilestoneStatus(m) }))
-    : buildSampleChecklist(PROGRESSION_MILESTONES.map((m) => m.label), 1)
-
-  const chickenEntries = animalTutorialState.chickenActive
-    ? CHICKEN_MILESTONES.map((m) => ({ label: m.label, status: getChickenMilestoneStatus(m) }))
-    : buildSampleChecklist(CHICKEN_MILESTONES.map((m) => m.label), 2)
-
-  const pigEntries = animalTutorialState.pigActive
-    ? PIG_MILESTONES.map((m) => ({ label: m.label, status: getPigMilestoneStatus(m) }))
-    : buildSampleChecklist(PIG_MILESTONES.map((m) => m.label), 2)
+  // These three guides are only ever rendered once the player has actually
+  // started or finished the flow (see the `xxxOwned` / `rotSystemUnlocked`
+  // OR-conditions below), so the real per-step status is always meaningful —
+  // no need for a fake placeholder once `active` (mid-session-resume only)
+  // goes back to false on a later reconnect.
+  const progressionEntries = PROGRESSION_MILESTONES.map((m) => ({ label: m.label, status: getProgressionMilestoneStatus(m) }))
+  const chickenEntries = CHICKEN_MILESTONES.map((m) => ({ label: m.label, status: getChickenMilestoneStatus(m) }))
+  const pigEntries = PIG_MILESTONES.map((m) => ({ label: m.label, status: getPigMilestoneStatus(m) }))
 
   if (tutorialState.active || QUEST_DEBUG) {
     items.push(makeGuideItem(


### PR DESCRIPTION
## Summary

Fixes two quest/tutorial soft-locks reported in #201 and #196, plus two related bugs found while verifying the fix (fake "sample" checklist in the Quest Panel, and a duplicate Mayor Chen NPC spawn).

## Root causes

**1. "Generate 5 Fertilizers" quest restarts every session (#201)**
`unlockFertilizerQuest()` migrates the fertilizer quest out of its hidden default state (`status: 'completed'`) whenever `rotSystemUnlocked` is true — this runs on every client boot. The same `'completed'` status is also set when the player genuinely finishes and claims the quest, so once claimed, the *next* login would flip it right back to `active` with `current: 0`.

**2. Chicken Coop / Pig Pen tutorials get permanently stuck asking the player to buy something they already own (#196, #201)**
Each tutorial step (`goToChickenBuyChicken`, `goToPigBuyPig`, etc.) waits on a one-shot callback tied to a *fresh* purchase/feed event (e.g. `chickens.length === 1` on the 0→1 transition). None of the steps checked whether the condition was already satisfied before waiting. A player who already owns the coop/pen and animals (e.g. a returning player who crosses the unlock level before this tutorial code shipped) gets stuck forever — `buyAnimal()` itself refuses further purchases once at the 5-animal cap, so the awaited event can never fire again.

**3. Quest Panel showed a fake, permanently-wrong progress card**
The "Fertilizer Guide" / "Chicken Coop" / "Pig Pen" guide cards in `QuestPanel.tsx` only showed real per-step progress while `xxxActive` (a runtime-only, resumed-this-session flag) was `true`. For any returning player who already finished the flow, `active` is `false` again, so the panel fell back to a hardcoded placeholder checklist instead of showing "all done." `progressionEventState.step` was also never rehydrated from the save on load, unlike the equivalent chicken/pig state.

**4. Duplicate Mayor Chen spawn**
`resumeChickenTutorial` / `resumePigTutorial` / `resumeProgressionEvent` (the reconnect-resume paths) were missing the `departAllActiveNpcs()` guard their `trigger*` siblings already had. Combined with a boot-order gap in `index.ts` — the welcome-tutorial branch didn't check whether an animal tutorial had already claimed Mayor — a save with both flows mid-flow simultaneously would spawn two independent Mayor Chen NPCs.

## Changes

- `src/game/questState.ts` — `unlockFertilizerQuest()` only migrates the quest when `current === 0` (never touched), leaving a genuinely completed quest alone.
- `src/systems/animalTutorialSystem.ts` — each coop/pen/feed step now checks if its goal is already met and skips ahead instead of waiting on a callback that can't fire again; added the missing `departAllActiveNpcs()` guard to the resume paths.
- `src/systems/progressionEventsSystem.ts` — same `departAllActiveNpcs()` guard added to `resumeProgressionEvent()`.
- `src/services/saveService.ts` — rehydrate `progressionEventState.step`/`.active` from the save on load.
- `src/ui/QuestPanel.tsx` — Fertilizer/Chicken/Pig guide cards always compute real per-step status instead of falling back to a fake sample checklist.
- `src/index.ts` — reordered the boot branch so an already-active animal tutorial takes priority over the welcome-tutorial Mayor spawn, preventing a duplicate NPC.

## Testing

- ✅ Manually verified: fertilizer quest stays `completed` across repeated reconnects (previously reset to `active`/`0` every time)
- ✅ Manually verified: chicken tutorial auto-advances past `buy_chicken` when the player already owns 5 chickens, instead of getting stuck
- ✅ Manually verified: duplicate Mayor Chen no longer spawns
- ⚠️ Pig tutorial fix uses the identical code path as the chicken fix (verified above) but wasn't independently re-tested live after the last round of changes — worth a quick smoke test before merge
- `npm run build` passes (bundling + type check)

Fixes #201
Fixes #196


## Linked issue

Closes #196 
Closes #201 

