### PR TITLE
ft: ci/auto-deploy-zone-on-pr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,11 +3,15 @@ name: Deploy
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 env:
   DCL_PRIVATE_KEY: ${{ secrets.DCL_WORLDS_PRIVATE_KEY }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  DEPLOY_ENV: ${{ github.event_name == 'pull_request' && 'testing' || 'production' }}
 
 jobs:
   deploy:
@@ -32,4 +36,4 @@ jobs:
     - name: Build scene
       run: npm run build
     - name: Deploy scene
-      run: npm run deploy:production
+      run: npm run deploy:${{ env.DEPLOY_ENV }}


### PR DESCRIPTION
## What changed
Added a `pull_request` trigger (opened/synchronize/reopened, targeting `main`) to the `deploy.yml` workflow, and introduced a `DEPLOY_ENV` variable that resolves to `testing` on `pull_request` events and `production` otherwise.

## Why
Every PR against `main` should automatically deploy to the testing environment (worlds-content-server.decentraland.zone) without a manual trigger, same as was just set up in survival-game.

## How it works
- `npm run deploy:testing` already existed in this repo (`--target-content https://worlds-content-server.decentraland.zone`), it just wasn't wired into CI.
- The deploy step now runs `npm run deploy:${{ env.DEPLOY_ENV }}` instead of a hardcoded `deploy:production`.
- `release` and `workflow_dispatch` still resolve to `production`, so existing behavior is unchanged for those triggers.

## Notes / limitations
- `secrets.DCL_WORLDS_PRIVATE_KEY` is not available on PRs from forks (standard GitHub Actions security behavior for `pull_request`). If external PRs are expected, we'd need `pull_request_target` or another approach.

## Test plan
- [ ] Open a test PR against `main` and confirm the "Deploy" job runs and publishes to `.zone`.
- [ ] Confirm a published `release` still deploys to production unchanged.


Closes #203 
