### PR TITLE
fix: switch Spanish copy to Spain dialect, polish language picker UI

### DIFF
--- a/src/i18n/dictionaries/animalTutorial.ts
+++ b/src/i18n/dictionaries/animalTutorial.ts
@@ -33,7 +33,7 @@ export const animalTutorialDict: TranslationDictionary = {
   'animalTutorial.chickenCleanIntro.button': { en: 'Thanks, Mayor!', es: '¡Gracias, Alcalde!', pt: 'Obrigado, Prefeito!' },
 
   'animalTutorial.chickenMayorClick.buyCoop':    { en: 'Head to the coop plot and tap to buy the Chicken Coop!', es: 'Ve a la parcela del gallinero y toca para comprar el Gallinero.', pt: 'Vá até o lote do galinheiro e toque para comprar o Galinheiro.' },
-  'animalTutorial.chickenMayorClick.buyChicken': { en: 'Open the shop (the computer) and buy your first chicken!', es: 'Abre la tienda (la computadora) y compra tu primera gallina.', pt: 'Abra a loja (o computador) e compre sua primeira galinha!' },
+  'animalTutorial.chickenMayorClick.buyChicken': { en: 'Open the shop (the computer) and buy your first chicken!', es: 'Abre la tienda (el ordenador) y compra tu primera gallina.', pt: 'Abra a loja (o computador) e compre sua primeira galinha!' },
   'animalTutorial.chickenMayorClick.feedChicken': { en: 'Tap the food bowl near the coop to deposit grain for your chickens!', es: 'Toca el comedero cerca del gallinero para depositar grano para tus gallinas.', pt: 'Toque no comedouro perto do galinheiro para depositar grãos para suas galinhas!' },
   'animalTutorial.chickenMayorClick.gotItButton': { en: 'Got it!', es: '¡Entendido!', pt: 'Entendi!' },
   'animalTutorial.chickenMayorClick.onItButton':  { en: 'On it!', es: '¡Voy!', pt: 'Pode deixar!' },
@@ -94,7 +94,7 @@ export const animalTutorialDict: TranslationDictionary = {
   'animalTutorial.pigHarvestExplained.button': { en: 'Thanks, Mayor!', es: '¡Gracias, Alcalde!', pt: 'Obrigado, Prefeito!' },
 
   'animalTutorial.pigMayorClick.buyPen':  { en: 'Head to the pig pen plot and tap to buy the Pig Pen!', es: 'Ve a la parcela del chiquero y toca para comprar el Chiquero.', pt: 'Vá até o lote do chiqueiro e toque para comprar o Chiqueiro.' },
-  'animalTutorial.pigMayorClick.buyPig':  { en: 'Open the shop (the computer) and buy your first pig!', es: 'Abre la tienda (la computadora) y compra tu primer cerdo.', pt: 'Abra a loja (o computador) e compre seu primeiro porco!' },
+  'animalTutorial.pigMayorClick.buyPig':  { en: 'Open the shop (the computer) and buy your first pig!', es: 'Abre la tienda (el ordenador) y compra tu primer cerdo.', pt: 'Abra a loja (o computador) e compre seu primeiro porco!' },
   'animalTutorial.pigMayorClick.feedPig': { en: 'Tap the food bowl near the pig pen to deposit food for your pigs!', es: 'Toca el comedero cerca del chiquero para depositar comida para tus cerdos.', pt: 'Toque no comedouro perto do chiqueiro para depositar comida para seus porcos!' },
   'animalTutorial.pigMayorClick.gotItButton': { en: 'Got it!', es: '¡Entendido!', pt: 'Entendi!' },
   'animalTutorial.pigMayorClick.onItButton':  { en: 'On it!', es: '¡Voy!', pt: 'Pode deixar!' },

--- a/src/i18n/dictionaries/data.ts
+++ b/src/i18n/dictionaries/data.ts
@@ -6,7 +6,7 @@ import type { TranslationDictionary } from '../types'
 export const dataDict: TranslationDictionary = {
   // ── Crops ──────────────────────────────────────────────────────────────────
   'data.crop.onion':     { en: 'Onion',     es: 'Cebolla',    pt: 'Cebola' },
-  'data.crop.potato':    { en: 'Potato',    es: 'Papa',       pt: 'Batata' },
+  'data.crop.potato':    { en: 'Potato',    es: 'Patata',     pt: 'Batata' },
   'data.crop.garlic':    { en: 'Garlic',    es: 'Ajo',        pt: 'Alho' },
   'data.crop.tomato':    { en: 'Tomato',    es: 'Tomate',     pt: 'Tomate' },
   'data.crop.carrot':    { en: 'Carrot',    es: 'Zanahoria',  pt: 'Cenoura' },
@@ -42,7 +42,7 @@ export const dataDict: TranslationDictionary = {
 
   // ── Level-up rewards ───────────────────────────────────────────────────────
   'data.levelReward.level2':  { en: '+5 Onion Seeds', es: '+5 Semillas de Cebolla', pt: '+5 Sementes de Cebola' },
-  'data.levelReward.level3':  { en: '+5 Potato Seeds', es: '+5 Semillas de Papa', pt: '+5 Sementes de Batata' },
+  'data.levelReward.level3':  { en: '+5 Potato Seeds', es: '+5 Semillas de Patata', pt: '+5 Sementes de Batata' },
   'data.levelReward.level5':  { en: '+3 Tomato Seeds', es: '+3 Semillas de Tomate', pt: '+3 Sementes de Tomate' },
   'data.levelReward.level7':  { en: '+3 Carrot Seeds', es: '+3 Semillas de Zanahoria', pt: '+3 Sementes de Cenoura' },
   'data.levelReward.level10': { en: '+500 Coins', es: '+500 Monedas', pt: '+500 Moedas' },

--- a/src/i18n/dictionaries/farmer.ts
+++ b/src/i18n/dictionaries/farmer.ts
@@ -15,7 +15,7 @@ export const farmerDict: TranslationDictionary = {
   'farmer.hireButton':        { en: 'Hire for {cost} coins', es: 'Contratar por {cost} monedas', pt: 'Contratar por {cost} moedas' },
   'farmer.workerUnpaidStatus': {
     en: { one: 'Worker unpaid: {wages} coins due ({count} day). Use the computer to clear wages.', other: 'Worker unpaid: {wages} coins due ({count} days). Use the computer to clear wages.' },
-    es: { one: 'Trabajador sin pagar: debes {wages} monedas ({count} día). Usa la computadora para saldar la deuda.', other: 'Trabajador sin pagar: debes {wages} monedas ({count} días). Usa la computadora para saldar la deuda.' },
+    es: { one: 'Trabajador sin pagar: debes {wages} monedas ({count} día). Usa el ordenador para saldar la deuda.', other: 'Trabajador sin pagar: debes {wages} monedas ({count} días). Usa el ordenador para saldar la deuda.' },
     pt: { one: 'Trabalhador sem pagamento: você deve {wages} moedas ({count} dia). Use o computador para quitar a dívida.', other: 'Trabalhador sem pagamento: você deve {wages} moedas ({count} dias). Use o computador para quitar a dívida.' },
   },
   'farmer.workerIdleNoSeeds': { en: 'Worker idle: no seeds loaded. Daily wage is {wage} coins.', es: 'Trabajador inactivo: no hay semillas cargadas. El salario diario es de {wage} monedas.', pt: 'Trabalhador ocioso: sem sementes carregadas. O salário diário é de {wage} moedas.' },

--- a/src/i18n/dictionaries/language.ts
+++ b/src/i18n/dictionaries/language.ts
@@ -3,7 +3,7 @@ import type { TranslationDictionary } from '../types'
 // Strings for the first-run Language Selection screen (src/ui/LanguageSelectOverlay.tsx),
 // plus display names usable later by any in-game language switcher.
 export const languageDict: TranslationDictionary = {
-  'language.title':  { en: 'Choose your language', es: 'Elegí tu idioma', pt: 'Escolha seu idioma' },
+  'language.title':  { en: 'Choose your language', es: 'Elige tu idioma', pt: 'Escolha seu idioma' },
   'language.select': { en: 'SELECT', es: 'SELECCIONAR', pt: 'SELECIONAR' },
   'language.name.en': { en: 'English', es: 'English', pt: 'English' },
   'language.name.es': { en: 'Español', es: 'Español', pt: 'Español' },

--- a/src/i18n/dictionaries/progressionEvents.ts
+++ b/src/i18n/dictionaries/progressionEvents.ts
@@ -77,7 +77,7 @@ export const progressionEventsDict: TranslationDictionary = {
   'progression.complete.button': { en: 'Thanks, Mayor!', es: '¡Gracias, Alcalde!', pt: 'Obrigado, Prefeito!' },
 
   // Re-shown when the player clicks Mayor mid-event
-  'progression.mayorClick.rotIntro':      { en: 'Head to the shop (the computer) and buy the Compost Bin for 300 coins!', es: 'Ve a la tienda (la computadora) y compra la Compostera por 300 monedas.', pt: 'Vá até a loja (o computador) e compre a Composteira por 300 moedas!' },
+  'progression.mayorClick.rotIntro':      { en: 'Head to the shop (the computer) and buy the Compost Bin for 300 coins!', es: 'Ve a la tienda (el ordenador) y compra la Compostera por 300 monedas.', pt: 'Vá até a loja (o computador) e compre a Composteira por 300 moedas!' },
   'progression.mayorClick.compostQuest':  { en: "Open the compost bin and add all 3 organic waste units. I've put them in your inventory!", es: 'Abre la compostera y agrega las 3 unidades de residuo orgánico. ¡Las puse en tu inventario!', pt: 'Abra a composteira e adicione as 3 unidades de resíduo orgânico. Coloquei elas no seu inventário!' },
   'progression.mayorClick.wasteQuest':    { en: "The bin is working — open it and collect your fertilizer once it's ready!", es: 'La compostera está funcionando — ábrela y recolecta tu fertilizante cuando esté listo.', pt: 'A composteira está funcionando — abra e colete seu fertilizante quando estiver pronto!' },
   'progression.mayorClick.collectQuest':  { en: "Plant a seed, water it, then apply a fertilizer. I'm waiting right here!", es: 'Planta una semilla, riégala y luego aplícale un fertilizante. ¡Te espero aquí mismo!', pt: 'Plante uma semente, regue e depois aplique um fertilizante. Estou esperando bem aqui!' },

--- a/src/i18n/dictionaries/tutorial.ts
+++ b/src/i18n/dictionaries/tutorial.ts
@@ -4,7 +4,7 @@ import type { TranslationDictionary } from '../types'
 export const tutorialDict: TranslationDictionary = {
   'tutorial.welcome.text': {
     en: "Welcome to CozyFarm! I'm Mayor Chen, and I'll guide you through the basics.\n\nHere are 15 coins to get you started — go inside your house and log into your computer to buy 5 Onion seeds on El Amazonas!",
-    es: '¡Bienvenido a CozyFarm! Soy el Alcalde Chen, y te voy a guiar por lo básico.\n\nAquí tienes 15 monedas para empezar — entra a tu casa e inicia sesión en tu computadora para comprar 5 semillas de cebolla en El Amazonas!',
+    es: '¡Bienvenido a CozyFarm! Soy el Alcalde Chen, y te voy a guiar por lo básico.\n\nAquí tienes 15 monedas para empezar — entra a tu casa e inicia sesión en tu ordenador para comprar 5 semillas de cebolla en El Amazonas!',
     pt: 'Bem-vindo à CozyFarm! Sou o Prefeito Chen, e vou te guiar pelo básico.\n\nAqui estão 15 moedas para você começar — entre na sua casa e acesse seu computador para comprar 5 sementes de cebola no El Amazonas!',
   },
   'tutorial.welcome.button': { en: 'Thanks, Mayor!', es: '¡Gracias, Alcalde!', pt: 'Obrigado, Prefeito!' },
@@ -66,7 +66,7 @@ export const tutorialDict: TranslationDictionary = {
     ],
     es: [
       '¡Lo lograste — ya eres un verdadero granjero! 🌱\n\nTe desbloqueé tres parcelas más.',
-      'Además, ve a tu computadora de la tienda — ¡las semillas de cebolla, papa y ajo ya están disponibles! Los cultivos de nivel 2 y 3 se desbloquean más adelante a medida que avances.',
+      'Además, ve a tu ordenador de la tienda — ¡las semillas de cebolla, patata y ajo ya están disponibles! Los cultivos de nivel 2 y 3 se desbloquean más adelante a medida que avances.',
       'El pueblo de CozyFarm está orgulloso de ti. ¡Buena suerte!',
     ],
     pt: [

--- a/src/ui/LanguageSelectOverlay.tsx
+++ b/src/ui/LanguageSelectOverlay.tsx
@@ -52,18 +52,25 @@ const FLAG_ORDER: Lang[] = ['en', 'es', 'pt']
 let previewLang: Lang = 'en'
 
 const FLAG_SIZE = ls(150)
+// Selected flag renders a bit bigger so tapping one visibly "pops" into
+// place instead of only changing via the border color.
+const FLAG_SIZE_SELECTED = ls(168)
 const FLAG_GAP = ls(40)
-const FLAGS_TOP = ls(280)
+// Row is sized to the larger (selected) flag so growth never clips; shifted
+// up by half the size delta to keep the row's visual center stable no
+// matter which flag (if any) is currently selected.
+const FLAGS_TOP = ls(280) - Math.round((FLAG_SIZE_SELECTED - FLAG_SIZE) / 2)
 const TITLE_TOP = ls(160)
 const BUTTON_TOP = ls(500)
 
 const FlagButton = ({ lang }: { key?: string; lang: Lang }) => {
   const selected = previewLang === lang
   const rect = FLAG_RECTS[lang]
+  const boxSize = selected ? FLAG_SIZE_SELECTED : FLAG_SIZE
 
   // Contain-fit the flag's real aspect ratio inside the inner box instead of
   // stretching it to a square (these are landscape flags, ~1.3:1 to 1.5:1).
-  const innerMax = FLAG_SIZE - ls(16)
+  const innerMax = boxSize - ls(16)
   const ratio = rect.w / rect.h
   let flagW = innerMax
   let flagH = Math.round(flagW / ratio)
@@ -75,8 +82,8 @@ const FlagButton = ({ lang }: { key?: string; lang: Lang }) => {
   return (
     <UiEntity
       uiTransform={{
-        width: FLAG_SIZE,
-        height: FLAG_SIZE,
+        width: boxSize,
+        height: boxSize,
         margin: { left: FLAG_GAP / 2, right: FLAG_GAP / 2 },
         borderWidth: ls(4),
         borderColor: selected ? FLAG_BORDER_SELECTED : FLAG_BORDER_IDLE,
@@ -168,7 +175,7 @@ export const LanguageSelectOverlay = () => {
             positionType: 'absolute',
             position: { top: FLAGS_TOP, left: 0 },
             width: BACKGROUND_W,
-            height: FLAG_SIZE,
+            height: FLAG_SIZE_SELECTED,
             flexDirection: 'row',
             justifyContent: 'center',
             alignItems: 'center',

--- a/src/ui/TopHud.tsx
+++ b/src/ui/TopHud.tsx
@@ -641,14 +641,16 @@ export const TopHud = () => {
           )}
         </UiEntity>
 
-        {/* Language switcher — shows the current language's flag; tap to reopen the picker. */}
+        {/* Language switcher — shows the current language's flag; tap to reopen the picker.
+            Desktop is shrunk 2.5x and nudged right (with breathing room from the screen
+            edge) vs. the mobile size; mobile keeps its original larger, more-left placement. */}
         <UiEntity
           uiTransform={{
             positionType: 'absolute',
-            position: { top: s(160), left: s(40) },
-            width: s(160),
-            height: s(160),
-            borderRadius: s(24),
+            position: mobile ? { top: s(160), left: s(40) } : { top: s(160), left: s(100) },
+            width: mobile ? s(160) : s(64),
+            height: mobile ? s(160) : s(64),
+            borderRadius: mobile ? s(24) : s(10),
             borderWidth: 2,
             borderColor: HUD_BROWN,
             alignItems: 'center',
@@ -662,7 +664,7 @@ export const TopHud = () => {
           }}
         >
           <UiEntity
-            uiTransform={{ width: s(120), height: s(80) }}
+            uiTransform={{ width: mobile ? s(120) : s(48), height: mobile ? s(80) : s(32) }}
             uiBackground={{
               texture: { src: LANG_FLAGS_IMG, wrapMode: 'clamp' },
               textureMode: 'stretch',


### PR DESCRIPTION
## Summary

Follow-up polish on top of the multilanguage system (#206): aligns the Spanish
copy with the Spain flag used in the picker, and improves the language
selection/switcher UI based on live testing feedback.

### Spain Spanish copy
- `computadora` → `ordenador` (with the article fixed accordingly, `la` → `el`)
- `papa` → `patata` (crop name + level-3 reward label)
- `Elegí tu idioma` → `Elige tu idioma` — the picker title was still in
  Argentine voseo (`vos` imperative) while the rest of the dictionary already
  uses `tú` forms; swept all 25 dictionaries for other stray voseo forms and
  confirmed this was the only one.

Touches `animalTutorial.ts`, `data.ts`, `farmer.ts`, `language.ts`,
`progressionEvents.ts`, `tutorial.ts` — `es` fields only, no `en`/`pt` changes.

### Language picker (`LanguageSelectOverlay.tsx`)
- The currently-selected flag now renders slightly larger (168px vs 150px)
  in addition to the existing gold border highlight, so tapping a flag reads
  as an active selection rather than just a border color change.
- Flags row height/offset adjusted so the larger flag never clips and the
  row's vertical center stays stable regardless of which flag is selected.

### HUD language switcher (`TopHud.tsx`)
- Desktop-only: shrunk 2.5x (160px → 64px) and nudged right (`left: 40` →
  `left: 100`) for better placement relative to the profile panel.
- Mobile is untouched — same size and position as before.

## Testing
- `npm run build` (type-check + bundle) clean after every change.
- Manual verification of the picker and HUD switcher in-game.


Closes #207 
